### PR TITLE
ignoring eclipse files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bin
+.classpath
+.project


### PR DESCRIPTION
Since some people prefer to not use Eclipse, they don't need these auto-generated files. Eclipse users just need to clone from github, create a new project with the same clone name, and then export jars from /lib to the classpath.
