### PR TITLE
Visit annotation fieldnode

### DIFF
--- a/src/org/designwizard/design/FieldNode.java
+++ b/src/org/designwizard/design/FieldNode.java
@@ -279,4 +279,21 @@ public class FieldNode extends AbstractEntity implements Entity {
 		
 	}
 
+	/**
+     * Returns the set of <code>ClassNode</code> representing the annotations annotating the entity
+     * represented by this <code>FieldNode</code>.
+     *
+     * @return the set of the annotations this object.
+     */
+	public Set<ClassNode> getAnnotations() {
+        Set<ClassNode> annotations = new HashSet<ClassNode>();
+        Set<Relation> isAnnotatedBy = super.getRelations(TypesOfRelation.IS_ANNOTATED_BY);
+
+        for (Relation relation : isAnnotatedBy) {
+            ClassNode outer = (ClassNode) relation.getCalledEntity();
+            annotations.add(outer);
+        }
+
+        return annotations;
+	}
 }

--- a/src/org/designwizard/extractor/asm/visitor/FactsExtractionClassVisitor.java
+++ b/src/org/designwizard/extractor/asm/visitor/FactsExtractionClassVisitor.java
@@ -139,7 +139,10 @@ public class FactsExtractionClassVisitor extends FactsEventSourceImpl {
 		
 		}
 		
-		return new FactsExtractionFieldVisitor();
+		FactsExtractionFieldVisitor fieldVisitor = new FactsExtractionFieldVisitor(field);
+		fieldVisitor.addListener(super.listeners.getFirst());
+		
+		return fieldVisitor;
 
 	}
 

--- a/src/org/designwizard/extractor/asm/visitor/FactsExtractionFieldVisitor.java
+++ b/src/org/designwizard/extractor/asm/visitor/FactsExtractionFieldVisitor.java
@@ -1,8 +1,34 @@
 package org.designwizard.extractor.asm.visitor;
 
+import org.designwizard.extractor.asm.event.FactEvent;
 import org.designwizard.extractor.asm.event.FactsEventSourceImpl;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.FieldVisitor;
 
 public class FactsExtractionFieldVisitor extends FactsEventSourceImpl implements FieldVisitor {
-// TODO nothing for a while.
+	
+	private String fieldName;
+
+	public FactsExtractionFieldVisitor(String fieldName) {
+		this.fieldName = fieldName;
+	}
+	
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		this.fieldName = name;
+		super.visit(version, access, name, signature, superName, interfaces);
+	}
+
+	@Override
+	public AnnotationVisitor visitAnnotation(String annotationName, boolean isVisible) {
+		// Cria um novo FactEvent para Annotations do FieldNode
+		super.factEvent = new FactEvent(FactsExtractionFieldVisitor.class, annotationName, isVisible);
+		super.fireAnnotationExtracted();
+
+		// Caller = classname and Called = desc (annotation)
+		super.factEvent = new FactEvent(FactsExtractionFieldVisitor.class, "ISANNOTATEDBY", this.fieldName, annotationName);
+		super.fireRelationExtracted();
+		
+		return super.visitAnnotation(annotationName, isVisible);
+	}
 }

--- a/src_tests/tests/org/designwizard/design/AnnotationsOfClassTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsOfClassTest.java
@@ -28,12 +28,44 @@ public class AnnotationsOfClassTest {
 
 	@Test
 	public void testGetAllAnnotations() {
+		ClassNode sigest, annotationA, annotationB, entity;
+		ClassNode id, oneToOne, oneToMany, column;
 		Set<ClassNode> annotations = dw.getAllAnnotations();
 
         for (ClassNode annotationNode : annotations) {
             assertTrue("Annotation: " + annotationNode.getName(), annotationNode.isAnnotation());
         }
-        assertEquals("1", 9, annotations.size());
+        assertFalse("1", annotations.isEmpty());
+        
+        try {
+        	sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
+        	annotationA = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
+        	annotationB = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+        	entity = dw.getClass("javax.persistence.Entity");
+        	
+        	// Anotações em Classes
+        	assertTrue("2", annotations.contains(annotationA));
+        	assertTrue("3", annotations.contains(annotationB));
+        	assertTrue("4", annotations.contains(entity));
+        	assertFalse("5", annotations.contains(sigest));
+        	
+        	// Criando o classNode que representa à anotação
+        	id = new ClassNode("javax.persistence.Id");
+        	
+        	// Buscando os classNodes que representam às anotações
+        	oneToOne = dw.getClass("javax.persistence.OneToOne");
+        	oneToMany = dw.getClass("javax.persistence.OneToMany");
+        	column = dw.getClass("javax.persistence.Column");
+        	
+        	// Anotações em Atributos
+        	assertTrue("6", annotations.contains(id));
+        	assertTrue("7", annotations.contains(oneToOne));
+        	assertTrue("8", annotations.contains(oneToMany));
+        	assertTrue("9", annotations.contains(column));
+        	
+        } catch (InexistentEntityException e) {
+			fail(e.getMessage());
+		}
 	}
 
 	@Test

--- a/src_tests/tests/org/designwizard/design/AnnotationsOfFieldTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsOfFieldTest.java
@@ -1,0 +1,58 @@
+package tests.org.designwizard.design;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Set;
+
+import org.designwizard.design.ClassNode;
+import org.designwizard.design.FieldNode;
+import org.designwizard.exception.InexistentEntityException;
+import org.designwizard.main.DesignWizard;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AnnotationsOfFieldTest {
+	
+	DesignWizard dw;
+	
+    @Before
+    public void setUp() throws Exception {
+    	String arquivoJar = "resources/sigest.jar";
+        dw = new DesignWizard(arquivoJar);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+	
+	@Test
+	public void testGetFieldsAnnotations() {
+		ClassNode curso;
+		FieldNode fieldNode;
+
+		try {
+			curso = dw.getClass("br.ufrn.cerescaico.bsi.sigest.model.Curso");
+			
+            fieldNode = curso.getField("codigo");
+            
+            Set<ClassNode> annotations = fieldNode.getAnnotations();
+            
+            ClassNode id = new ClassNode("javax.persistence.Id");
+            
+            assertTrue("1", annotations.contains(id));
+            assertEquals("2", 4, annotations.size());
+            
+            fieldNode = curso.getField("serialVersionUID");
+            annotations = fieldNode.getAnnotations();
+			
+            assertEquals("3", 0, annotations.size());
+
+		} catch (InexistentEntityException e) {
+			fail(e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
Implementação da recuperação de anotações de atributos #15.
Foi adicionada a extração da informação na classe FactsExtractionFieldVisitor e modificado o retorno do visitField na classe FactsExtractionClassVisitor. O restante dos métodos de recuperação de anotações de classe foi reutilizado.
Foi necessário apenas implementar o método getAnnotations() na classe FieldNode.
Criei um classe de teste e melhorei a classe de testes de anotações de classes.