### PR TITLE
Fixed warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
 			<url>https://github.com/Gustavohqo</url>
 			<id>Gustavohqo</id>
 		</developer>
+		<developer>
+			<email>catharinequintans@gmail.com</email>
+			<name>Catharine Quintans</name>
+			<url>https://github.com/catharinequintans</url>
+			<id>catharinequintans</id>
+		</developer>
 	</developers>
 
 	<dependencies>
@@ -189,7 +195,7 @@
 				</executions>
 				<configuration>
                     <!--  -Xdoclint:all -->
-                    <!-- <additionalparam>-Xdoclint:none</additionalparam> -->
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
 			</plugin>
 			<plugin>

--- a/src/org/designwizard/api/util/FileUtil.java
+++ b/src/org/designwizard/api/util/FileUtil.java
@@ -30,11 +30,9 @@ public class FileUtil {
 	
 	public static boolean writeResult(File file, String contents) {
 		Writer output = null;
-	    try {
-	      FileWriter localFile = new FileWriter(file);
+	    try (FileWriter localFile = new FileWriter(file)) {
 	      output = new BufferedWriter(localFile);
 	      output.write(contents);
-	      localFile.close();
 	    } catch (IOException e) {
 			return false;
 		} 

--- a/src/org/designwizard/api/util/FileUtil.java
+++ b/src/org/designwizard/api/util/FileUtil.java
@@ -31,8 +31,10 @@ public class FileUtil {
 	public static boolean writeResult(File file, String contents) {
 		Writer output = null;
 	    try {
-	      output = new BufferedWriter( new FileWriter(file) );
-	      output.write( contents );
+	      FileWriter localFile = new FileWriter(file);
+	      output = new BufferedWriter(localFile);
+	      output.write(contents);
+	      localFile.close();
 	    } catch (IOException e) {
 			return false;
 		} 

--- a/src/org/designwizard/design/AbstractEntity.java
+++ b/src/org/designwizard/design/AbstractEntity.java
@@ -198,7 +198,18 @@ public abstract class AbstractEntity implements Entity {
 	
 	@Override
 	public int hashCode() {
-		return this.name.hashCode();
+		return this.name.hashCode() + this.type.hashCode() + modifiers.hashCode();
 	}
 	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof AbstractEntity)) {
+			return false; 
+		 } else {
+	        AbstractEntity abstractEntity = (AbstractEntity) obj;
+	        return this.name.equals(abstractEntity.getName()) &&
+	        	   this.type.equals(abstractEntity.getTypeOfEntity()) &&
+	        	   this.modifiers.equals(abstractEntity.getModifiers());
+	    }
+	}
 }

--- a/src/org/designwizard/extractor/asm/ASMExtractor.java
+++ b/src/org/designwizard/extractor/asm/ASMExtractor.java
@@ -74,7 +74,7 @@ public class ASMExtractor implements Extractor {
 			}
 
 		}
-
+		classLoader.close();
 	}
 
 	private String removeDirectoryName(String fileName) {

--- a/src/org/designwizard/extractor/asm/ASMExtractor.java
+++ b/src/org/designwizard/extractor/asm/ASMExtractor.java
@@ -36,7 +36,7 @@ public class ASMExtractor implements Extractor {
 		JarFile jarFile = new JarFile(fileName);
 		Enumeration<JarEntry> e = jarFile.entries();
 
-		URL[] urls = { new File(fileName).toURL() };
+		URL[] urls = { new File(fileName).toURI().toURL() };
 		URLClassLoader classLoader = new URLClassLoader(urls, null);
 
 		while (e.hasMoreElements()) {
@@ -57,7 +57,7 @@ public class ASMExtractor implements Extractor {
 	public void processDir(String fileName) throws IOException {
 
 		File file = new File(fileName);
-		URLClassLoader classLoader = new URLClassLoader(new URL[] { new File(fileName).toURL() });
+		URLClassLoader classLoader = new URLClassLoader(new URL[] { new File(fileName).toURI().toURL() });
 
 		if (file.isFile() && file.getName().endsWith(".class")) {
 
@@ -199,7 +199,7 @@ public class ASMExtractor implements Extractor {
 	@Override
 	public void processClass(String classFilePath) throws IOException {
 		URLClassLoader classLoader = new URLClassLoader(
-				new URL[] { new File(classFilePath).toURL() });
+				new URL[] { new File(classFilePath).toURI().toURL() });
 		classFilePath = removeDirectoryName(classFilePath);
 		processClass(classFilePath, classLoader);
 	}

--- a/src/org/designwizard/extractor/asm/ASMExtractor.java
+++ b/src/org/designwizard/extractor/asm/ASMExtractor.java
@@ -46,7 +46,7 @@ public class ASMExtractor implements Extractor {
 				this.processClass(entryName, classLoader);
 			}
 		}
-
+		jarFile.close();
 	}
 
 	/*

--- a/src/org/designwizard/extractor/asm/util/ClassPathHacker.java
+++ b/src/org/designwizard/extractor/asm/util/ClassPathHacker.java
@@ -19,7 +19,7 @@ public class ClassPathHacker {
 	}
 	 
 	public void addFile(File file) throws IOException {
-		addURL(file.toURL());
+		addURL(file.toURI().toURL());
 	}
 	 	 
 	private void addURL(URL url) throws IOException {

--- a/src_tests/tests/org/designwizard/design/AbstractEntityTest.java
+++ b/src_tests/tests/org/designwizard/design/AbstractEntityTest.java
@@ -2,8 +2,6 @@ package tests.org.designwizard.design;
 
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.AbstractEntity;
 import org.designwizard.design.ClassNode;
@@ -13,33 +11,36 @@ import org.designwizard.design.Modifier;
 import org.designwizard.design.factory.AbstractElementsFactory;
 import org.designwizard.design.factory.ElementsFactory;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class AbstractEntityTest extends TestCase {
+public class AbstractEntityTest {
 	
 	private static final String DESIGNWIZARD_DIR = "classes";
 	private DesignWizard dw;
 
+	@Test
 	public void testIsAbstract() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 		
 		AbstractEntity abstractClass = this.dw.getClass(AbstractEntity.class);
-		assertTrue(abstractClass.isAbstract());
+		Assert.assertTrue(abstractClass.isAbstract());
 		
 		abstractClass = this.dw.getClass(AbstractElementsFactory.class);
-		assertTrue(abstractClass.isAbstract());
+		Assert.assertTrue(abstractClass.isAbstract());
 		
 		abstractClass = this.dw.getClass(AbstractElementsFactory.class);
-		assertTrue(abstractClass.isAbstract());
+		Assert.assertTrue(abstractClass.isAbstract());
 		
 		AbstractEntity concreteClass = this.dw.getClass(ElementsFactory.class);
-		assertFalse(concreteClass.isAbstract());
+		Assert.assertFalse(concreteClass.isAbstract());
 		
 		AbstractEntity abstractMethod = this.dw.getMethod("org.designwizard.design.Entity.getName()");
-		assertTrue(abstractMethod.isAbstract());
+		Assert.assertTrue(abstractMethod.isAbstract());
 	}
 	
 	/**
-	 * Todos os m�todos na interface s�o p�blicos e abstratos
+	 * Todos os métodos na interface são públicos e abstratos
 	 * @throws InexistentEntityException
 	 * @throws IOException 
 	 */
@@ -47,11 +48,11 @@ public class AbstractEntityTest extends TestCase {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 		ClassNode interfaceEntity = this.dw.getClass(Entity.class);
 		
-		assertTrue(interfaceEntity.isAbstract());
+		Assert.assertTrue(interfaceEntity.isAbstract());
 		
 		for (MethodNode method: interfaceEntity.getAllMethods()) {
-			assertTrue(method.isAbstract());
-			assertTrue(method.getVisibility().equals(Modifier.PUBLIC));
+			Assert.assertTrue(method.isAbstract());
+			Assert.assertTrue(method.getVisibility().equals(Modifier.PUBLIC));
 		}
 	}
 }

--- a/src_tests/tests/org/designwizard/design/AllClassesInSuiteTest.java
+++ b/src_tests/tests/org/designwizard/design/AllClassesInSuiteTest.java
@@ -3,14 +3,13 @@ package tests.org.designwizard.design;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.exception.InexistentEntityException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import tests.suites.AllTests;
 
 public class AllClassesInSuiteTest {

--- a/src_tests/tests/org/designwizard/design/AllClassesInSuiteTest.java
+++ b/src_tests/tests/org/designwizard/design/AllClassesInSuiteTest.java
@@ -8,15 +8,18 @@ import junit.framework.TestCase;
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Test;
 
 import tests.suites.AllTests;
 
-public class AllClassesInSuiteTest extends TestCase {
+public class AllClassesInSuiteTest {
 	
 	private DesignWizard dw;
 	private static final String DESIGNWIZARD_HEADLINE = "org.";
 	private static final String DESIGNWIZARD_DIR = "classes";
 	
+	@Test
 	public void testAllTestClassIsHere() throws IOException, InexistentEntityException {
 		
 		dw = new DesignWizard(DESIGNWIZARD_DIR);
@@ -28,15 +31,9 @@ public class AllClassesInSuiteTest extends TestCase {
 		testClasses.remove(testedClass);
 		
 		for (ClassNode subClass : testClasses) {
-			
 			if (subClass.getClassNode().getName().startsWith(DESIGNWIZARD_HEADLINE)) {
-			
-				assertTrue("The class "+subClass.getName()+" is not in the suite.",subClass.getCallerClasses().contains(testedClass));
-			
+				Assert.assertTrue("The class "+subClass.getName()+" is not in the suite.",subClass.getCallerClasses().contains(testedClass));
 			}
-		
 		}
-	
 	}
-
 }

--- a/src_tests/tests/org/designwizard/design/AnnotationsExtractTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsExtractTest.java
@@ -7,10 +7,9 @@ import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.exception.InexistentEntityException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import junit.framework.TestCase;
 
 /**
  * Test for Issue 39 - Absence of the annotation modifier in external class extraction
@@ -33,7 +32,7 @@ import junit.framework.TestCase;
  *
  * @author Taciano Morais Silva <tacianosilva@gmail.com>
  */
-public class AnnotationsExtractTest extends TestCase {
+public class AnnotationsExtractTest {
 
     private DesignWizard dw;
 
@@ -53,7 +52,7 @@ public class AnnotationsExtractTest extends TestCase {
         // Internal Classes of the project
         Set<ClassNode> classes = dw.getAllClasses();
 
-        assertEquals("total classes: ", 8, classes.size());
+        Assert.assertEquals("total classes: ", 8, classes.size());
     }
 
     @Test
@@ -61,7 +60,7 @@ public class AnnotationsExtractTest extends TestCase {
         //Total used annotation (internal e external)
         Set<ClassNode> annotations = dw.getAllAnnotations();
 
-        assertEquals("total annotations: ", 7, annotations.size());
+        Assert.assertEquals("total annotations: ", 7, annotations.size());
     }
 
     @Test
@@ -69,13 +68,13 @@ public class AnnotationsExtractTest extends TestCase {
         //external annotation and unused
         ClassNode entityA = dw.getClass("tests.org.designwizard.design.mocks.annotations.external.AnnotationA");
 
-        assertNotNull("AnnotationA is not null?", entityA);
-        assertTrue("AnnotationA is annotation?", !entityA.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityA);
+        Assert.assertTrue("AnnotationA is annotation?", !entityA.isAnnotation());
 
         // Classes annotated by external annotationA
         Set<ClassNode> classesA = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.external.AnnotationA");
-        assertEquals("Num classes annotated by AnnotationB", 0, classesA.size());
+        Assert.assertEquals("Num classes annotated by AnnotationB", 0, classesA.size());
     }
 
     @Test
@@ -83,24 +82,19 @@ public class AnnotationsExtractTest extends TestCase {
         //external annotation and used
         ClassNode entityB = dw.getClass("tests.org.designwizard.design.mocks.annotations.external.AnnotationB");
 
-        assertNotNull("AnnotationA is not null?", entityB);
-        assertTrue("AnnotationA is annotation?", entityB.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityB);
+        Assert.assertTrue("AnnotationA is annotation?", entityB.isAnnotation());
 
         // Classes annotated by external annotationB
         Set<ClassNode> classesB = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.external.AnnotationB");
-        assertEquals("Num classes annotated by AnnotationB", 1, classesB.size());
+        Assert.assertEquals("Num classes annotated by AnnotationB", 1, classesB.size());
     }
 
-    @Test
+    @Test(expected=InexistentEntityException.class)
     public void testExtractAnnotationC() throws InexistentEntityException {
         //external annotation, is not called and unused (it isn't extracted)
-        try {
-            dw.getClass("tests.org.designwizard.design.mocks.annotations.external.AnnotationC");
-            fail("This method must throw the exception: InexistentEntityException");
-        } catch(InexistentEntityException e) {
-            assertTrue(true);
-        }
+        dw.getClass("tests.org.designwizard.design.mocks.annotations.external.AnnotationC");
     }
 
     @Test
@@ -108,13 +102,13 @@ public class AnnotationsExtractTest extends TestCase {
         //internal annotation and used
         ClassNode entityD = dw.getClass("tests.org.designwizard.design.mocks.annotations.issue39.AnnotationD");
 
-        assertNotNull("AnnotationA is not null?", entityD);
-        assertTrue("AnnotationA is annotation?", entityD.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityD);
+        Assert.assertTrue("AnnotationA is annotation?", entityD.isAnnotation());
 
         // Classes annotated by internal annotationD
         Set<ClassNode> classesD = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.issue39.AnnotationD");
-        assertEquals("Num classes annotated by AnnotationD", 1, classesD.size());
+        Assert.assertEquals("Num classes annotated by AnnotationD", 1, classesD.size());
     }
 
     @Test
@@ -122,13 +116,13 @@ public class AnnotationsExtractTest extends TestCase {
         //internal annotation and unused
         ClassNode entityE = dw.getClass("tests.org.designwizard.design.mocks.annotations.issue39.AnnotationE");
 
-        assertNotNull("AnnotationA is not null?", entityE);
-        assertTrue("AnnotationA is annotation?", entityE.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityE);
+        Assert.assertTrue("AnnotationA is annotation?", entityE.isAnnotation());
 
         // Classes annotated by internal annotationE
         Set<ClassNode> classesE = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.issue39.AnnotationE");
-        assertEquals("Num classes annotated by AnnotationE", 0, classesE.size());
+        Assert.assertEquals("Num classes annotated by AnnotationE", 0, classesE.size());
     }
 
     @Test
@@ -136,13 +130,13 @@ public class AnnotationsExtractTest extends TestCase {
         //internal annotation and used
         ClassNode entityF = dw.getClass("tests.org.designwizard.design.mocks.annotations.issue39.AnnotationF");
 
-        assertNotNull("AnnotationA is not null?", entityF);
-        assertTrue("AnnotationA is annotation?", entityF.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityF);
+        Assert.assertTrue("AnnotationA is annotation?", entityF.isAnnotation());
 
         // Classes annotated by internal annotationF
         Set<ClassNode> classesF = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.issue39.AnnotationF");
-        assertEquals("Num classes annotated by AnnotationF", 1, classesF.size());
+        Assert.assertEquals("Num classes annotated by AnnotationF", 1, classesF.size());
     }
 
     @Test
@@ -150,13 +144,13 @@ public class AnnotationsExtractTest extends TestCase {
         //internal annotation and unused
         ClassNode entityG = dw.getClass("tests.org.designwizard.design.mocks.annotations.issue39.AnnotationG");
 
-        assertNotNull("AnnotationA is not null?", entityG);
-        assertTrue("AnnotationA is annotation?", entityG.isAnnotation());
+        Assert.assertNotNull("AnnotationA is not null?", entityG);
+        Assert.assertTrue("AnnotationA is annotation?", entityG.isAnnotation());
 
         // Classes annotated by internal annotationG
         Set<ClassNode> classesG = classesByAnnotation(dw,
                 "tests.org.designwizard.design.mocks.annotations.issue39.AnnotationG");
-        assertEquals("Num classes annotated by AnnotationG", 0, classesG.size());
+        Assert.assertEquals("Num classes annotated by AnnotationG", 0, classesG.size());
     }
 
     public static Set<ClassNode> classesByAnnotation(DesignWizard dw, String annotationName) throws InexistentEntityException {

--- a/src_tests/tests/org/designwizard/design/AnnotationsOfClassTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsOfClassTest.java
@@ -7,12 +7,11 @@ import org.designwizard.design.ClassNode;
 import org.designwizard.design.Entity;
 import org.designwizard.exception.InexistentEntityException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import junit.framework.TestCase;
-
-public class AnnotationsOfClassTest extends TestCase {
+public class AnnotationsOfClassTest {
 	
 	DesignWizard dw;
 	
@@ -28,136 +27,112 @@ public class AnnotationsOfClassTest extends TestCase {
     }
 
 	@Test
-	public void testGetAllAnnotations() {
+	public void testGetAllAnnotations() throws InexistentEntityException {
 		ClassNode sigest, annotationA, annotationB, entity;
 		ClassNode id, oneToOne, oneToMany, column;
 		Set<ClassNode> annotations = dw.getAllAnnotations();
 
-        for (ClassNode annotationNode : annotations) {
-            assertTrue("Annotation: " + annotationNode.getName(), annotationNode.isAnnotation());
-        }
-        assertFalse("1", annotations.isEmpty());
-        
-        try {
-        	sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
-        	annotationA = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
-        	annotationB = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-        	entity = dw.getClass("javax.persistence.Entity");
-        	
-        	// Anotações em Classes
-        	assertTrue("2", annotations.contains(annotationA));
-        	assertTrue("3", annotations.contains(annotationB));
-        	assertTrue("4", annotations.contains(entity));
-        	assertFalse("5", annotations.contains(sigest));
-        	
-        	// Criando o classNode que representa à anotação
-        	id = new ClassNode("javax.persistence.Id");
-        	
-        	// Buscando os classNodes que representam às anotações
-        	oneToOne = dw.getClass("javax.persistence.OneToOne");
-        	oneToMany = dw.getClass("javax.persistence.OneToMany");
-        	column = dw.getClass("javax.persistence.Column");
-        	
-        	// Anotações em Atributos
-        	assertTrue("6", annotations.contains(id));
-        	assertTrue("7", annotations.contains(oneToOne));
-        	assertTrue("8", annotations.contains(oneToMany));
-        	assertTrue("9", annotations.contains(column));
-        	
-        } catch (InexistentEntityException e) {
-			fail(e.getMessage());
+		for (ClassNode annotationNode : annotations) {
+			Assert.assertTrue("Annotation: " + annotationNode.getName(), annotationNode.isAnnotation());
 		}
+		Assert.assertFalse("1", annotations.isEmpty());
+
+		sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
+		annotationA = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
+		annotationB = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		entity = dw.getClass("javax.persistence.Entity");
+
+		// Anotações em Classes
+		Assert.assertTrue("2", annotations.contains(annotationA));
+		Assert.assertTrue("3", annotations.contains(annotationB));
+		Assert.assertTrue("4", annotations.contains(entity));
+		Assert.assertFalse("5", annotations.contains(sigest));
+
+		// Criando o classNode que representa à anotação
+		id = new ClassNode("javax.persistence.Id");
+
+		// Buscando os classNodes que representam às anotações
+		oneToOne = dw.getClass("javax.persistence.OneToOne");
+		oneToMany = dw.getClass("javax.persistence.OneToMany");
+		column = dw.getClass("javax.persistence.Column");
+
+		// Anotações em Atributos
+		Assert.assertTrue("6", annotations.contains(id));
+		Assert.assertTrue("7", annotations.contains(oneToOne));
+		Assert.assertTrue("8", annotations.contains(oneToMany));
+		Assert.assertTrue("9", annotations.contains(column));
 	}
 
 	@Test
-	public void testIsAnnotationClass() {
+	public void testIsAnnotationClass() throws InexistentEntityException {
 		ClassNode sigest, annotationA, annotationB, entity;
-		try {
-			sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
-			annotationA = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
-			annotationB = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-			entity = dw.getClass("javax.persistence.Entity");
+		sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
+		annotationA = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
+		annotationB = dw.getClass("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		entity = dw.getClass("javax.persistence.Entity");
 
-	        assertTrue("1", sigest.isClass());
-	        assertFalse("2", sigest.isAnnotation());
-	        assertTrue("3", annotationA.isAnnotation());
-	        assertTrue("4", annotationB.isAnnotation());
-	        assertTrue("5", entity.isAnnotation());
-		} catch (InexistentEntityException e) {
-			fail(e.getMessage());
-		}
+		Assert.assertTrue("1", sigest.isClass());
+		Assert.assertFalse("2", sigest.isAnnotation());
+		Assert.assertTrue("3", annotationA.isAnnotation());
+		Assert.assertTrue("4", annotationB.isAnnotation());
+		Assert.assertTrue("5", entity.isAnnotation());
 	}
 	
 	@Test
-	public void testGetClassesAnnotatedBy() {
+	public void testGetClassesAnnotatedBy() throws InexistentEntityException {
         Set<Entity> classes = null;
-		try {
-			classes = dw.getEntitiesAnnotatedBy("javax.persistence.Entity");
-			assertEquals("1", 11, classes.size());
-			
-			classes = dw.getEntitiesAnnotatedBy("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
-			assertEquals("2", 2, classes.size());
-			
-			classes = dw.getEntitiesAnnotatedBy("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-			assertEquals("3", 0, classes.size());
-		} catch (InexistentEntityException e) {
-			fail(e.getMessage());
-		}
+		classes = dw.getEntitiesAnnotatedBy("javax.persistence.Entity");
+		Assert.assertEquals("1", 11, classes.size());
+
+		classes = dw.getEntitiesAnnotatedBy("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
+		Assert.assertEquals("2", 2, classes.size());
+
+		classes = dw.getEntitiesAnnotatedBy("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		Assert.assertEquals("3", 0, classes.size());
 	}
 	
 	@Test
-	public void testGetAnnotation() {
+	public void testGetAnnotation() throws InexistentEntityException {
 		ClassNode entity, annotationA, annotationB, sigest;
-		try {
-			entity = dw.getAnnotation("javax.persistence.Entity");
-			annotationA = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-			annotationB = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-			sigest = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.Sigest");
-			
-			
-			assertNull("1", sigest);
-			assertNotNull("2", entity);
-			assertNotNull("3", annotationA);
-			assertNotNull("4", annotationB);
-	        assertTrue("5", annotationA.isAnnotation());
-	        assertTrue("6", annotationB.isAnnotation());
-	        assertTrue("7", entity.isAnnotation());
-			
-		} catch (InexistentEntityException e) {
-			fail(e.getMessage());
-		}
+		entity = dw.getAnnotation("javax.persistence.Entity");
+		annotationA = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		annotationB = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		sigest = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.Sigest");
+
+		Assert.assertNull("1", sigest);
+		Assert.assertNotNull("2", entity);
+		Assert.assertNotNull("3", annotationA);
+		Assert.assertNotNull("4", annotationB);
+		Assert.assertTrue("5", annotationA.isAnnotation());
+		Assert.assertTrue("6", annotationB.isAnnotation());
+		Assert.assertTrue("7", entity.isAnnotation());
 	}
 	
 	@Test
-	public void testGetAnnotatedClasses() {
+	public void testGetAnnotatedClasses() throws InexistentEntityException {
 		ClassNode entity, annotationA, annotationB, sigest;
 		Set<Entity> classesAnnotationA, classesAnnotationB, classesEntity, classesSigest;
-		try {
-			entity = dw.getAnnotation("javax.persistence.Entity");
-			annotationA = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
-			annotationB = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
-			sigest = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.Sigest");
-			
-			assertNull("0", sigest);
-			
-			classesAnnotationA = annotationA.getEntitiesAnnotatedBy();
-			classesAnnotationB = annotationB.getEntitiesAnnotatedBy();
-			classesEntity = entity.getEntitiesAnnotatedBy();
-			
-			sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
-			classesSigest = sigest.getEntitiesAnnotatedBy();
-			
-			assertNotNull("1", classesAnnotationA);
-			assertEquals("2", 2, classesAnnotationA.size());
-	        assertNotNull("3", classesAnnotationB);
-	        assertEquals("4", 0, classesAnnotationB.size());
-	        assertNotNull("5", classesEntity);
-	        assertEquals("6", 11, classesEntity.size());
-	        assertNotNull("7", classesSigest);
-	        assertEquals("8", 0, classesSigest.size());
-			
-		} catch (InexistentEntityException e) {
-			fail(e.getMessage());
-		}
+		entity = dw.getAnnotation("javax.persistence.Entity");
+		annotationA = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationA");
+		annotationB = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.annotation.AnnotationB");
+		sigest = dw.getAnnotation("br.ufrn.cerescaico.bsi.sigest.Sigest");
+
+		Assert.assertNull("0", sigest);
+
+		classesAnnotationA = annotationA.getEntitiesAnnotatedBy();
+		classesAnnotationB = annotationB.getEntitiesAnnotatedBy();
+		classesEntity = entity.getEntitiesAnnotatedBy();
+
+		sigest = dw.getClass("br.ufrn.cerescaico.bsi.sigest.Sigest");
+		classesSigest = sigest.getEntitiesAnnotatedBy();
+
+		Assert.assertNotNull("1", classesAnnotationA);
+		Assert.assertEquals("2", 2, classesAnnotationA.size());
+		Assert.assertNotNull("3", classesAnnotationB);
+		Assert.assertEquals("4", 0, classesAnnotationB.size());
+		Assert.assertNotNull("5", classesEntity);
+		Assert.assertEquals("6", 11, classesEntity.size());
+		Assert.assertNotNull("7", classesSigest);
+		Assert.assertEquals("8", 0, classesSigest.size());
 	}
 }

--- a/src_tests/tests/org/designwizard/design/AnnotationsOfFieldTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsOfFieldTest.java
@@ -7,50 +7,44 @@ import org.designwizard.design.ClassNode;
 import org.designwizard.design.FieldNode;
 import org.designwizard.exception.InexistentEntityException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import junit.framework.TestCase;
+public class AnnotationsOfFieldTest {
 
-public class AnnotationsOfFieldTest extends TestCase {
-	
 	DesignWizard dw;
-	
-    @Before
-    public void setUp() throws Exception {
-    	String arquivoJar = "resources/sigest.jar";
-        dw = new DesignWizard(arquivoJar);
-    }
 
-    @After
-    public void tearDown() throws Exception {
+	@Before
+	public void setUp() throws Exception {
+		String arquivoJar = "resources/sigest.jar";
+		dw = new DesignWizard(arquivoJar);
+	}
 
-    }
-	
+	@After
+	public void tearDown() throws Exception {
+
+	}
+
 	@Test
-	public void testGetFieldsAnnotations() {
+	public void testGetFieldsAnnotations() throws InexistentEntityException {
 		ClassNode curso;
 		FieldNode fieldNode;
 
-		try {
-			curso = dw.getClass("br.ufrn.cerescaico.bsi.sigest.model.Curso");
-			
-            fieldNode = curso.getField("codigo");
-            
-            Set<ClassNode> annotations = fieldNode.getAnnotations();
-            
-            ClassNode id = new ClassNode("javax.persistence.Id");
-            
-            assertTrue("1", annotations.contains(id));
-            assertEquals("2", 4, annotations.size());
-            
-            fieldNode = curso.getField("serialVersionUID");
-            annotations = fieldNode.getAnnotations();
-			
-            assertEquals("3", 0, annotations.size());
+		curso = dw.getClass("br.ufrn.cerescaico.bsi.sigest.model.Curso");
 
-		} catch (InexistentEntityException e) {
-			fail(e.getMessage());
-		}
+		fieldNode = curso.getField("codigo");
+
+		Set<ClassNode> annotations = fieldNode.getAnnotations();
+
+		ClassNode id = new ClassNode("javax.persistence.Id");
+
+		Assert.assertTrue("1", annotations.contains(id));
+		Assert.assertEquals("2", 4, annotations.size());
+
+		fieldNode = curso.getField("serialVersionUID");
+		annotations = fieldNode.getAnnotations();
+
+		Assert.assertEquals("3", 0, annotations.size());
 	}
 }

--- a/src_tests/tests/org/designwizard/design/AnnotationsOfMethodTest.java
+++ b/src_tests/tests/org/designwizard/design/AnnotationsOfMethodTest.java
@@ -1,15 +1,11 @@
 package tests.org.designwizard.design;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.MethodNode;
 import org.designwizard.exception.InexistentEntityException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,130 +24,107 @@ public class AnnotationsOfMethodTest {
 
     }
     
-    
     /**
      * Tests the extraction of annotation on methods and annotation 
      * on parameters of these methods.
+     * @throws InexistentEntityException 
      */
     @Test
-    public void testGetMethodsAnnotations() {
-    	ClassNode anexo;
+    public void testGetMethodsAnnotations() throws InexistentEntityException {
+		ClassNode anexo;
 		MethodNode methodNode;
-		
-		try{
-			anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
-			methodNode = anexo.getDeclaredMethod("getAnexo(java.lang.Long)");
-			
-			ClassNode parameterAnnotation = new ClassNode("javax.ws.rs.PathParam");
-			ClassNode annotation = new ClassNode("javax.ws.rs.Path");
 
-			assertTrue("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
-			assertTrue("3 - contains parameterAnnotation", methodNode.getAnnotations().contains(parameterAnnotation));
-			assertEquals("2 - Size", 4, methodNode.getAnnotations().size());
-			
-		}catch(InexistentEntityException e){
-			fail(e.getMessage());
-		}
+		anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
+		methodNode = anexo.getDeclaredMethod("getAnexo(java.lang.Long)");
+
+		ClassNode parameterAnnotation = new ClassNode("javax.ws.rs.PathParam");
+		ClassNode annotation = new ClassNode("javax.ws.rs.Path");
+
+		Assert.assertTrue("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
+		Assert.assertTrue("3 - contains parameterAnnotation", methodNode.getAnnotations().contains(parameterAnnotation));
+		Assert.assertEquals("2 - Size", 4, methodNode.getAnnotations().size());
     }
     
     /**
      * Tests the extraction of multiple annotations
      * on parameters of methods.
+     * @throws InexistentEntityException 
      */
     @Test
-    public void getMultipleParametersAnnotationTest() {
+    public void getMultipleParametersAnnotationTest() throws InexistentEntityException {
     	ClassNode anexo;
 		MethodNode methodNode;
 		
-		try{
-			anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
-			methodNode = anexo.getDeclaredMethod("getAnexoMultipleParams(java.lang.Long,java.lang.Long)");
-			
-			ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
-			ClassNode paramAnnotation2 = new ClassNode("javax.ws.rs.PathParam");
-			assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
-			assertTrue("3 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation2));
-			assertEquals("4 - Size", 3, methodNode.getAnnotations().size());
-			
-		}catch(InexistentEntityException e){
-			fail(e.getMessage());
-		}
+		anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
+		methodNode = anexo.getDeclaredMethod("getAnexoMultipleParams(java.lang.Long,java.lang.Long)");
+
+		ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
+		ClassNode paramAnnotation2 = new ClassNode("javax.ws.rs.PathParam");
+		Assert.assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
+		Assert.assertTrue("3 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation2));
+		Assert.assertEquals("4 - Size", 3, methodNode.getAnnotations().size());
     }
-    
     
     /**
      * Tests the extraction of identical annotations presented on methods
      * and their parameters
+     * @throws InexistentEntityException 
      */
     @Test
-    public void equalParamAndMethodAnnoteTest() {
+    public void equalParamAndMethodAnnoteTest() throws InexistentEntityException {
     	ClassNode anexo;
 		MethodNode methodNode;
 		
-		try{
-			anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
-			methodNode = anexo.getDeclaredMethod("getCaso(java.lang.Long)");
-			
-			ClassNode annotation = new ClassNode("javax.ws.rs.Path");
-			assertFalse("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
+		anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
+		methodNode = anexo.getDeclaredMethod("getCaso(java.lang.Long)");
 
-			ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
-			assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
-			assertEquals("3 - Size", 2, methodNode.getAnnotations().size());
-			
-		}catch(InexistentEntityException e){
-			fail(e.getMessage());
-		}
+		ClassNode annotation = new ClassNode("javax.ws.rs.Path");
+		Assert.assertFalse("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
+
+		ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
+		Assert.assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
+		Assert.assertEquals("3 - Size", 2, methodNode.getAnnotations().size());
     }
     
     /**
      * Tests extraction of annotations in methods with no annotations
      * or parameters annotations
+     * @throws InexistentEntityException 
      */
     @Test
-    public void noneAnnotationTest() {
+    public void noneAnnotationTest() throws InexistentEntityException {
     	ClassNode anexo;
 		MethodNode methodNode;
 		
-		try{
-			anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
-			methodNode = anexo.getDeclaredMethod("getNome(java.lang.String)");
-			
-			ClassNode annotation = new ClassNode("javax.ws.rs.Path");
-			assertFalse("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
+		anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
+		methodNode = anexo.getDeclaredMethod("getNome(java.lang.String)");
 
-			ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
-			assertFalse("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
-			assertEquals("3 - Size", 0, methodNode.getAnnotations().size());
-			
-		}catch(InexistentEntityException e){
-			fail(e.getMessage());
-		}
+		ClassNode annotation = new ClassNode("javax.ws.rs.Path");
+		Assert.assertFalse("1 - contains anotation", methodNode.getAnnotations().contains(annotation));
+
+		ClassNode paramAnnotation1 = new ClassNode("javax.ws.rs.PathParam");
+		Assert.assertFalse("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(paramAnnotation1));
+		Assert.assertEquals("3 - Size", 0, methodNode.getAnnotations().size());
     }
     
     /**
      * Tests extraction of annotations in methods with no annotation on
      * parameters
+     * @throws InexistentEntityException 
      */
     @Test
-    public void annotationOnlyInMethodsTest() {
-    	ClassNode anexo;
+    public void annotationOnlyInMethodsTest() throws InexistentEntityException {
+		ClassNode anexo;
 		MethodNode methodNode;
-		
-		try{
-			anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
-			methodNode = anexo.getDeclaredMethod("setAnexo(java.lang.String)");
-			
-			ClassNode annotation1 = new ClassNode("javax.ws.rs.Path");
-			assertTrue("1 - contains anotation", methodNode.getAnnotations().contains(annotation1));
 
-			ClassNode annotation2 = new ClassNode("javax.ws.rs.POST");
-			assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(annotation2));
-			assertEquals("3 - Size", 3, methodNode.getAnnotations().size());
-			
-		}catch(InexistentEntityException e){
-			fail(e.getMessage());
-		}
+		anexo = dw.getClass("tests.org.designwizard.design.mocks.Anexo");
+		methodNode = anexo.getDeclaredMethod("setAnexo(java.lang.String)");
+
+		ClassNode annotation1 = new ClassNode("javax.ws.rs.Path");
+		Assert.assertTrue("1 - contains anotation", methodNode.getAnnotations().contains(annotation1));
+
+		ClassNode annotation2 = new ClassNode("javax.ws.rs.POST");
+		Assert.assertTrue("2 - contains parameterAnnotation", methodNode.getAnnotations().contains(annotation2));
+		Assert.assertEquals("3 - Size", 3, methodNode.getAnnotations().size());
     }
-
 }

--- a/src_tests/tests/org/designwizard/design/CatchBlockTest.java
+++ b/src_tests/tests/org/designwizard/design/CatchBlockTest.java
@@ -3,13 +3,14 @@ package tests.org.designwizard.design;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.MethodNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class CatchBlockTest extends TestCase {
+public class CatchBlockTest {
 
 	/**
 	 * Attribute
@@ -21,22 +22,23 @@ public class CatchBlockTest extends TestCase {
 	 * @throws IOException
 	 * @throws InexistentEntityException 
 	 */
-	@Override
-	protected void setUp() throws IOException, InexistentEntityException {
+	@Before
+	public void setUp() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"trycatchblock.jar");
 	}
 	
+	@Test
 	public void testCatchBlock() throws InexistentEntityException {
 		
 		MethodNode method = this.dw.getMethod("ClassWithManyCatchBlocks.main(java.lang.String[])");
-		assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.NumberFormatException.class)));
-		assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.IllegalArgumentException.class)));
+		Assert.assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.NumberFormatException.class)));
+		Assert.assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.IllegalArgumentException.class)));
 	
 		method = this.dw.getMethod("ClassWithManyCatchBlocks.<init>()");
-		assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.io.IOException.class)));
+		Assert.assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.io.IOException.class)));
 		
 		method = this.dw.getMethod("ClassWithManyCatchBlocks.catchRuntimeException()");
-		assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.IllegalArgumentException.class)));
-		assertTrue(method.getCatchedExceptions().contains(this.dw.getClass("MyException")));
+		Assert.assertTrue(method.getCatchedExceptions().contains(this.dw.getClass(java.lang.IllegalArgumentException.class)));
+		Assert.assertTrue(method.getCatchedExceptions().contains(this.dw.getClass("MyException")));
 	}
 }

--- a/src_tests/tests/org/designwizard/design/CatchedExceptionsTest.java
+++ b/src_tests/tests/org/designwizard/design/CatchedExceptionsTest.java
@@ -4,22 +4,24 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.MethodNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class CatchedExceptionsTest extends TestCase {
+public class CatchedExceptionsTest {
 
 	private DesignWizard dw;
 	
-	@Override
+	@Before
 	public void setUp() throws IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"trycatchblock.jar");
 	}
 	
+	@Test
 	public void testNonExceptionCatch() throws InexistentEntityException {
 		ClassNode testedClass = this.dw.getClass(Exception.class);
 		Set<ClassNode> classes = this.dw.getAllClasses();
@@ -27,7 +29,7 @@ public class CatchedExceptionsTest extends TestCase {
 			Set<MethodNode> methods = clazz.getAllMethods();
 			for (MethodNode method: methods) {
 				Set<ClassNode> exceptions = method.getCatchedExceptions();
-				assertFalse("The method "+method.getName()+" catches Exception. Fix it!.",exceptions.contains(testedClass));
+				Assert.assertFalse("The method "+method.getName()+" catches Exception. Fix it!.",exceptions.contains(testedClass));
 			}
 		}
 	}

--- a/src_tests/tests/org/designwizard/design/ClassNodeTest.java
+++ b/src_tests/tests/org/designwizard/design/ClassNodeTest.java
@@ -46,9 +46,10 @@ public class ClassNodeTest {
 	
 	@Test
 	public void testLoadClass() throws IOException, InexistentEntityException {
+		//FIXME Adequar esses testes para nova suíte de testes.
 		MethodNode allTest = dw.getMethod(AllTests.class.getName()+".suite()");
 		Set<ClassNode> usedBy = allTest.getCalleeClasses();
-		
+				
 		ClassNode loaded = this.dw.getClass(RelationTest.class);
 		Assert.assertTrue(usedBy.remove(loaded));
 		

--- a/src_tests/tests/org/designwizard/design/ClassNodeTest.java
+++ b/src_tests/tests/org/designwizard/design/ClassNodeTest.java
@@ -4,9 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.common.Config;
 import org.designwizard.design.AbstractEntity;
@@ -23,55 +20,61 @@ import org.designwizard.exception.InexistentEntityException;
 import org.designwizard.exception.InvalidTypeOfVisibility;
 import org.designwizard.exception.NotAnInterfaceException;
 import org.designwizard.patternchecker.ResultListener;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
+import junit.framework.TestSuite;
 import tests.org.designwizard.design.relation.RelationTest;
 import tests.suites.AllTests;
 
-public class ClassNodeTest extends TestCase {
+public class ClassNodeTest {
 	
 	private DesignWizard dw;
 	private static final String DESIGNWIZARD_DIR = "classes";
 	
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		this.dw = null;
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 	}	
 	
+	@Test
 	public void testLoadClass() throws IOException, InexistentEntityException {
 		MethodNode allTest = dw.getMethod(AllTests.class.getName()+".suite()");
 		Set<ClassNode> usedBy = allTest.getCalleeClasses();
 		
 		ClassNode loaded = this.dw.getClass(RelationTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(CatchBlockTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(CatchedExceptionsTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(tests.org.designwizard.design.RedBarTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(FieldNodeTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(ClassNodeTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(AllClassesInSuiteTest.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 		
 		loaded = this.dw.getClass(TestSuite.class);
-		assertTrue(usedBy.remove(loaded));
+		Assert.assertTrue(usedBy.remove(loaded));
 	}
 
+	@Test
 	public void testIsPrimitive() throws IOException, InexistentEntityException {
 		ClassNode entity;
 		
@@ -79,148 +82,154 @@ public class ClassNodeTest extends TestCase {
 		
 		MethodNode method = this.dw.getMethod("AllMethod.voidReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.intReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.byteReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.charReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.booleanReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.doubleReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.floatReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.longReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.charReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.typeReturn()");
 		entity = method.getReturnType();
-		assertFalse(entity.isPrimitive());
+		Assert.assertFalse(entity.isPrimitive());
 		
 		method = this.dw.getMethod("AllMethod.shortReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isPrimitive());
+		Assert.assertTrue(entity.isPrimitive());
 	}
 	
+	@Test
 	public void testIsArray() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"returnmethod.jar");
 		MethodNode method = this.dw.getMethod("AllMethod.intArrayReturn()");
 		ClassNode entity = method.getReturnType();
-		assertTrue(entity.isArray());
+		Assert.assertTrue(entity.isArray());
 		
 		method = this.dw.getMethod("AllMethod.intArrayReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isArray());
+		Assert.assertTrue(entity.isArray());
 		
 		method = this.dw.getMethod("AllMethod.int2ArrayReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isArray());
+		Assert.assertTrue(entity.isArray());
 		
 		method = this.dw.getMethod("AllMethod.shortArrayReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isArray());
+		Assert.assertTrue(entity.isArray());
 		
 		method = this.dw.getMethod("AllMethod.short2ArrayReturn()");
 		entity = method.getReturnType();
-		assertTrue(entity.isArray());
+		Assert.assertTrue(entity.isArray());
 		
 		method = this.dw.getMethod("AllMethod.typeReturn()");
 		entity = method.getReturnType();
-		assertFalse(entity.isArray());
+		Assert.assertFalse(entity.isArray());
 	}
 	
+	@Test
 	public void testImplementedInterfaces() throws InexistentEntityException, IOException {
 		// No interface is implemented.
 		ClassNode classNode = this.dw.getClass(ClassNode.class);
 		Set<ClassNode> implementedInterfaces = classNode.getImplementedInterfaces();
-		assertEquals(1,implementedInterfaces.size());
-		assertTrue(implementedInterfaces.contains(this.dw.getClass(Entity.class)));
+		Assert.assertEquals(1,implementedInterfaces.size());
+		Assert.assertTrue(implementedInterfaces.contains(this.dw.getClass(Entity.class)));
 		
 		classNode = this.dw.getClass(AbstractEntity.class);
 		implementedInterfaces = classNode.getImplementedInterfaces();
-		assertEquals(1,implementedInterfaces.size());
-		assertEquals(this.dw.getClass(Entity.class), implementedInterfaces.iterator().next());
+		Assert.assertEquals(1,implementedInterfaces.size());
+		Assert.assertEquals(this.dw.getClass(Entity.class), implementedInterfaces.iterator().next());
 		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"implements2Interfaces.jar");
 		classNode = this.dw.getClass("SingletonBadConstructor");
 		implementedInterfaces = classNode.getImplementedInterfaces();
-		assertEquals(2,implementedInterfaces.size());
+		Assert.assertEquals(2,implementedInterfaces.size());
 	}
 	
+	@Test
 	public void testGetPackage() throws IOException, InexistentEntityException {
 		
 		ClassNode classNode = this.dw.getClass(Config.class);
-		assertEquals("org.designwizard.common", classNode.getPackage().getName());
+		Assert.assertEquals("org.designwizard.common", classNode.getPackage().getName());
 		
 		classNode = this.dw.getClass(AbstractElementsFactory.class);
-		assertEquals("org.designwizard.design.factory", classNode.getPackage().getName());
+		Assert.assertEquals("org.designwizard.design.factory", classNode.getPackage().getName());
 		
 		classNode = this.dw.getClass(ClassNodeTest.class);
-		assertEquals("tests.org.designwizard.design", classNode.getPackage().getName());
+		Assert.assertEquals("tests.org.designwizard.design", classNode.getPackage().getName());
 		
 		ClassNode anotherClassNode = this.dw.getClass(FieldNodeTest.class);
-		assertEquals(anotherClassNode.getPackage().getName(), classNode.getPackage().getName());
+		Assert.assertEquals(anotherClassNode.getPackage().getName(), classNode.getPackage().getName());
 		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"visibility.jar");
 		classNode = this.dw.getClass("PackageClass");
-		assertEquals("default",classNode.getPackage().getName());
+		Assert.assertEquals("default",classNode.getPackage().getName());
 	}
 	
+	@Test
 	public void testIsInterface() throws InexistentEntityException {
 		ClassNode interfaceEntity = this.dw.getClass(Entity.class);
-		assertTrue(interfaceEntity.isInterface());
+		Assert.assertTrue(interfaceEntity.isInterface());
 		
 		interfaceEntity = this.dw.getClass(DesignIF.class);
-		assertTrue(interfaceEntity.isInterface());
-		assertTrue(interfaceEntity.containsModifiers(Modifier.ABSTRACT));
+		Assert.assertTrue(interfaceEntity.isInterface());
+		Assert.assertTrue(interfaceEntity.containsModifiers(Modifier.ABSTRACT));
 		
 		interfaceEntity = this.dw.getClass(ResultListener.class);
-		assertTrue(interfaceEntity.isInterface());
+		Assert.assertTrue(interfaceEntity.isInterface());
 		
 		interfaceEntity = this.dw.getClass(AbstractElementsFactory.class);
-		assertTrue(interfaceEntity.isInterface());
+		Assert.assertTrue(interfaceEntity.isInterface());
 		
 		ClassNode classEntity = this.dw.getClass(ClassNodeTest.class);
-		assertFalse(classEntity.isInterface());
+		Assert.assertFalse(classEntity.isInterface());
 		
 		classEntity = this.dw.getClass(AbstractEntity.class);
-		assertFalse(classEntity.isInterface());
-		assertTrue(interfaceEntity.containsModifiers(Modifier.ABSTRACT));
+		Assert.assertFalse(classEntity.isInterface());
+		Assert.assertTrue(interfaceEntity.containsModifiers(Modifier.ABSTRACT));
 		
 		classEntity = this.dw.getClass(FieldNode.class);
-		assertFalse(classEntity.isInterface());
-		assertFalse(classEntity.containsModifiers(Modifier.ABSTRACT));
+		Assert.assertFalse(classEntity.isInterface());
+		Assert.assertFalse(classEntity.containsModifiers(Modifier.ABSTRACT));
 		
 		classEntity = this.dw.getClass(FieldNodeTest.class);
-		assertFalse(classEntity.isInterface());
+		Assert.assertFalse(classEntity.isInterface());
 	}
 	
+	@Test
 	public void testGetCallers() throws InexistentEntityException {
 		ClassNode classNode = this.dw.getClass(ClassNodeTest.class);
 		Set<MethodNode> callers = classNode.getCallerMethods();
-		assertTrue(callers.contains(this.dw.getMethod("tests.suites.AllTests.suite()")));
+		Assert.assertTrue(callers.contains(this.dw.getMethod("tests.suites.AllTests.suite()")));
 	}
 	
+	@Test
 	public void testInheritedFieldsAndMethods() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 		
@@ -229,137 +238,134 @@ public class ClassNodeTest extends TestCase {
 		
 		Set<MethodNode> inheritedMethods = classNode.getInheritedMethods();
 		for (MethodNode method: abstractEntity.getAllMethods()) {
-			assertTrue(method.getName(),inheritedMethods.contains(method));
+			Assert.assertTrue(method.getName(),inheritedMethods.contains(method));
 		}
 		
-		assertEquals(inheritedMethods.size(), abstractEntity.getAllMethods().size());
+		Assert.assertEquals(inheritedMethods.size(), abstractEntity.getAllMethods().size());
 		
 		Set<MethodNode> declaredMethods = classNode.getDeclaredMethods();
 		MethodNode method = this.dw.getMethod("org.designwizard.design.ClassNode.<init>(java.lang.String)");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.addRelation(org.designwizard.design.relation.Relation)");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.addInheritedField(org.designwizard.design.FieldNode)");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getShortName()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getAllMethods()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getStaticMethods()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getCallerClasses()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getCalleeClasses()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getSuperClass()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getSubClasses()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getMethods(org.designwizard.design.Modifier[])");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getConstructors()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getDeclaredFields()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getImpactOfAChange()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.toString()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.printComponents(java.util.Set)");
-		assertTrue(declaredMethods.contains(method));
-		
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.equals(java.lang.Object)");
-		assertTrue(declaredMethods.contains(method));
-		
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getCallerMethods()");
-		assertTrue(declaredMethods.contains(method));
-		
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getInheritedFields()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getAllFields()");
-		assertTrue(declaredMethods.contains(method));
-		
+		Assert.assertTrue(declaredMethods.contains(method));
 		
 		method = this.dw.getMethod("org.designwizard.design.ClassNode.getInheritedFields()");
-		assertTrue(declaredMethods.contains(method));
+		Assert.assertTrue(declaredMethods.contains(method));
 	}
 	
+	@Test(expected=NotAnInterfaceException.class)
 	public void testGetEntitiesThatImplements() throws IOException, InexistentEntityException, NotAnInterfaceException {
 		ClassNode entity = dw.getClass(AbstractEntity.class);
 		Set<ClassNode> implementsEntity = null;
-		try {
-			implementsEntity = entity.getEntitiesThatImplements();
-			fail("This line can not be executed");
-		} catch (NotAnInterfaceException e) {} 
+		
+		implementsEntity = entity.getEntitiesThatImplements();
 		
 		entity = dw.getClass(Entity.class);
 		implementsEntity = entity.getEntitiesThatImplements();
 		
-		assertTrue(implementsEntity.contains(dw.getClass(AbstractEntity.class)));
-		assertTrue(implementsEntity.contains(dw.getClass(FieldNode.class)));
-		assertTrue(implementsEntity.contains(dw.getClass(ClassNode.class)));
-		assertTrue(implementsEntity.contains(dw.getClass(MethodNode.class)));
-		assertTrue(implementsEntity.contains(dw.getClass(PackageNode.class)));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(AbstractEntity.class)));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(FieldNode.class)));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(ClassNode.class)));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(MethodNode.class)));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(PackageNode.class)));
 		
-		assertEquals(5,implementsEntity.size());
+		Assert.assertEquals(5,implementsEntity.size());
 		
 		entity = dw.getClass(DesignIF.class);
 		implementsEntity = entity.getEntitiesThatImplements();
 		
-		assertTrue(implementsEntity.contains(dw.getClass(Design.class)));
-		assertEquals(1,implementsEntity.size());
+		Assert.assertTrue(implementsEntity.contains(dw.getClass(Design.class)));
+		Assert.assertEquals(1,implementsEntity.size());
 		
 		dw = new DesignWizard("resources/testFiles/impactwithinheritance.jar");
 		entity = dw.getClass("IVeiculo");
 		implementsEntity = entity.getEntitiesThatImplements();
 		
-		assertTrue(implementsEntity.contains(dw.getClass("IMoto")));
-		assertTrue(implementsEntity.contains(dw.getClass("ICarro")));
-		assertEquals(2,implementsEntity.size());
+		Assert.assertTrue(implementsEntity.contains(dw.getClass("IMoto")));
+		Assert.assertTrue(implementsEntity.contains(dw.getClass("ICarro")));
+		Assert.assertEquals(2,implementsEntity.size());
 		
 		entity = dw.getClass("IMoto");
 		implementsEntity = entity.getEntitiesThatImplements();
-		assertTrue(implementsEntity.contains(dw.getClass("Moto")));
-		assertEquals(1,implementsEntity.size());
+		Assert.assertTrue(implementsEntity.contains(dw.getClass("Moto")));
+		Assert.assertEquals(1,implementsEntity.size());
 		
 		entity = dw.getClass("ICarro");
 		implementsEntity = entity.getEntitiesThatImplements();
-		assertTrue(implementsEntity.contains(dw.getClass("Carro")));
-		assertEquals(1,implementsEntity.size());
+		Assert.assertTrue(implementsEntity.contains(dw.getClass("Carro")));
+		Assert.assertEquals(1,implementsEntity.size());
 	}
 	
+	@Test
 	public void testGetAllMethodsWithVisibilityAndStaticOption() throws IOException, InvalidTypeOfVisibility, InexistentEntityException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		
 		// dont forget the default constructors.
 		ClassNode classEntity = this.dw.getClass("AccessModifiers");
 		Set<MethodNode> allMethods = classEntity.getMethods(Modifier.PUBLIC, Modifier.STATIC);
-		assertEquals(allMethods.size(),1);
+		Assert.assertEquals(allMethods.size(),1);
 		
 		classEntity = this.dw.getClass("MorePublic");
 		allMethods = classEntity.getMethods(Modifier.PUBLIC, Modifier.STATIC);
-		assertEquals(allMethods.size(),1);
+		Assert.assertEquals(allMethods.size(),1);
 	}
 	
+	@Test
 	public void testGetAllMethods() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		
@@ -369,20 +375,21 @@ public class ClassNodeTest extends TestCase {
 		for (ClassNode clazz : allClasses) {
 			total+=clazz.getAllMethods().size();
 		}
-		assertEquals(total,21);
+		Assert.assertEquals(total,21);
 	}
 	
+	@Test
 	public void testGetWithVisibilityAndStaticOption() throws IOException, InexistentEntityException, InvalidTypeOfVisibility{
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		
 		Set<MethodNode> allMethods = this.dw.getClass("AccessModifiers").getAllMethods();
-		assertEquals(allMethods.size(),9);
+		Assert.assertEquals(allMethods.size(),9);
 		
 		Set<MethodNode> methods = this.dw.getClass("AccessModifiers").getMethods(Modifier.PUBLIC,Modifier.STATIC);
-		assertEquals(methods.size(),1);
+		Assert.assertEquals(methods.size(),1);
 		
 		methods = this.dw.getClass("MorePublic").getMethods(Modifier.PUBLIC, Modifier.STATIC);
-		assertEquals(methods.size(),1);
+		Assert.assertEquals(methods.size(),1);
 		
 		/**
 		 * Methods public and static
@@ -392,15 +399,14 @@ public class ClassNodeTest extends TestCase {
 		for (MethodNode method: methods) {
 			if (method.containsModifiers(Modifier.STATIC)) count+=1;
 		}
-		assertEquals(count,1);
+		Assert.assertEquals(count,1);
 		
 		methods = this.dw.getClass("MorePublic").getMethods(Modifier.PUBLIC);
 		count = 0;
 		for (MethodNode method: methods) {
 			if (method.containsModifiers(Modifier.STATIC)) count+=1;
 		}
-		assertEquals(count,1);
-		
+		Assert.assertEquals(count,1);
 		
 		/**
 		 * Looking for methods that are just public
@@ -410,94 +416,99 @@ public class ClassNodeTest extends TestCase {
 		for (MethodNode method: methods) {
 			if (!method.containsModifiers(Modifier.STATIC)) count+=1;
 		}
-		assertEquals(count,1);
+		Assert.assertEquals(count,1);
 		
 		methods = this.dw.getClass("MorePrivate").getMethods(Modifier.PUBLIC);
-		assertEquals(methods.size(),1);
+		Assert.assertEquals(methods.size(),1);
 		
 		methods = this.dw.getClass("MorePrivate").getMethods(Modifier.PUBLIC);
-		assertEquals(methods.size(),1);
+		Assert.assertEquals(methods.size(),1);
 	}
 	
+	@Test
 	public void testGetWithVisibility() throws IOException, InexistentEntityException, InvalidTypeOfVisibility{
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		
 		Set<MethodNode> allMethods = this.dw.getClass("AccessModifiers").getAllMethods();
-		assertEquals(allMethods.size(),9);
+		Assert.assertEquals(allMethods.size(),9);
 		
 		// remember that the classes without constructors have a default public constructor
 		Set<MethodNode> methods = this.dw.getClass("AccessModifiers").getMethods(Modifier.PUBLIC);
-		assertEquals(methods.size(),3);
+		Assert.assertEquals(methods.size(),3);
 		
 		methods = this.dw.getClass("AccessModifiers").getMethods(Modifier.PRIVATE);
-		assertEquals(methods.size(),2);
+		Assert.assertEquals(methods.size(),2);
 	
 		methods = this.dw.getClass("AccessModifiers").getMethods(Modifier.PROTECTED);
-		assertEquals(methods.size(),2);
+		Assert.assertEquals(methods.size(),2);
 	
 		methods = this.dw.getClass("AccessModifiers").getMethods(Modifier.PACKAGE);
-		assertEquals(methods.size(),2);
+		Assert.assertEquals(methods.size(),2);
 	}
 	
+	@Test
 	public void testGetAllMethodsInClass() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		Set<MethodNode> methods = this.dw.getClass("AccessModifiers").getAllMethods();
-		assertEquals(9,methods.size());
+		Assert.assertEquals(9,methods.size());
 		
 		MethodNode method = this.dw.getMethod("AccessModifiers.pus(java.lang.String[])");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.pros()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.pris()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.fris()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.pub()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.pri()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.pro()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.fri()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 		
 		method = this.dw.getMethod("AccessModifiers.<init>()");
-		assertTrue(methods.contains(method));
+		Assert.assertTrue(methods.contains(method));
 	}
 	
+	@Test
 	public void testGetSubClasses() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"hierarchy.jar");
 		ClassNode clazz = this.dw.getClass("SuperClass");
 		Set<ClassNode> subClasses = clazz.getSubClasses();
-		assertEquals(subClasses.size(),2);
-		assertTrue(subClasses.contains(this.dw.getClass("SubClass")));
-		assertTrue(subClasses.contains(this.dw.getClass("ExtendsAndImplements")));
+		Assert.assertEquals(subClasses.size(),2);
+		Assert.assertTrue(subClasses.contains(this.dw.getClass("SubClass")));
+		Assert.assertTrue(subClasses.contains(this.dw.getClass("ExtendsAndImplements")));
 			
 		subClasses = this.dw.getClass("Interface").getSubClasses();
-		assertEquals(subClasses.size(),0);
+		Assert.assertEquals(subClasses.size(),0);
 	}
 	
+	@Test
 	public void testGetClass() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("classes");
 		ClassNode classEntity = this.dw.getClass(DesignWizard.class);
-		assertTrue(classEntity.containsModifiers(Modifier.PUBLIC));
-		assertFalse(classEntity.containsModifiers(Modifier.STATIC));
-		assertEquals(1,classEntity.getModifiers().size());
+		Assert.assertTrue(classEntity.containsModifiers(Modifier.PUBLIC));
+		Assert.assertFalse(classEntity.containsModifiers(Modifier.STATIC));
+		Assert.assertEquals(1,classEntity.getModifiers().size());
 	}
 	
+	@Test
 	public void testGetSuperClasses() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"hierarchy.jar");
 		ClassNode superClass = this.dw.getClass("SubClass").getSuperClass();
-		assertEquals(superClass, this.dw.getClass("SuperClass"));
+		Assert.assertEquals(superClass, this.dw.getClass("SuperClass"));
 		superClass = this.dw.getClass("ExtendsAndImplements").getSuperClass();
-		assertEquals(superClass, this.dw.getClass("SuperClass"));
+		Assert.assertEquals(superClass, this.dw.getClass("SuperClass"));
 	}
 	
 	/**
@@ -506,12 +517,14 @@ public class ClassNodeTest extends TestCase {
 	 * @throws IOException 
 	 *
 	 */
+	@Test
 	public void testNumStaticMethods() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		Set<MethodNode> staticMethods = this.dw.getClass("AccessModifiers").getStaticMethods();
-		assertEquals(4,staticMethods.size());
+		Assert.assertEquals(4,staticMethods.size());
 	}	
 	
+	@Test
 	public void testGetClassesThatUses() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"edados1.jar");
 	
@@ -519,47 +532,48 @@ public class ClassNodeTest extends TestCase {
 		Set<ClassNode> ius;
 		MethodNode m = this.dw.getMethod("Inteiro.ehInteiro(char)");
 		ius = m.getCallerClasses();
-		assertTrue(ius.contains(this.dw.getClass("Polinomio")));
-		assertEquals(1,ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("Polinomio")));
+		Assert.assertEquals(1,ius.size());
 		
 		FieldNode f = this.dw.getField("java.lang.System.in");
 		ius = f.getCallerClasses();
-		assertTrue(ius.contains(this.dw.getClass("CalculadoraMain")));
-		assertEquals(1,ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("CalculadoraMain")));
+		Assert.assertEquals(1,ius.size());
 		
 		f = this.dw.getField("Logica.mapaEntrada");
 		ius = f.getCallerClasses();
-		assertTrue(ius.contains(this.dw.getClass("Logica")));
-		assertTrue(ius.contains(this.dw.getClass("Polinomio")));
-		assertEquals(2,ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("Logica")));
+		Assert.assertTrue(ius.contains(this.dw.getClass("Polinomio")));
+		Assert.assertEquals(2,ius.size());
 		
 		f = this.dw.getField("Polinomio.map");
 		ius = f.getCallerClasses();
-		assertTrue(ius.contains(this.dw.getClass("Polinomio")));
-		assertEquals(1, ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("Polinomio")));
+		Assert.assertEquals(1, ius.size());
 		
 		f = this.dw.getField("java.lang.System.out");
 		ius = f.getCallerClasses();
-		assertEquals(1, ius.size());
-		assertTrue(ius.contains(this.dw.getClass("CalculadoraMain")));
+		Assert.assertEquals(1, ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("CalculadoraMain")));
 		
 		f = this.dw.getField("pacote.outro.Teste.variavel");
 		ius = f.getCallerClasses();
-		assertEquals(1, ius.size());
-		assertTrue(ius.contains(this.dw.getClass("pacote.ClasseDentroDoPacote")));
+		Assert.assertEquals(1, ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("pacote.ClasseDentroDoPacote")));
 		
 		ClassNode clazz = this.dw.getClass("pacote.outro.Teste");
 		ius = clazz.getCallerClasses();
-		assertEquals(1, ius.size());
-		assertTrue(ius.contains(this.dw.getClass("pacote.ClasseDentroDoPacote")));
+		Assert.assertEquals(1, ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("pacote.ClasseDentroDoPacote")));
 		
 		clazz = this.dw.getClass("TratamentosComuns");
 		ius = clazz.getCallerClasses();
-		assertEquals(2, ius.size());
-		assertTrue(ius.contains(this.dw.getClass("Logica")));
-		assertTrue(ius.contains(this.dw.getClass("Polinomio")));
+		Assert.assertEquals(2, ius.size());
+		Assert.assertTrue(ius.contains(this.dw.getClass("Logica")));
+		Assert.assertTrue(ius.contains(this.dw.getClass("Polinomio")));
 	}
 	
+	@Test
 	public void testGetClassesUsedBy() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"edados1.jar");
 		
@@ -567,162 +581,160 @@ public class ClassNodeTest extends TestCase {
 		
 		MethodNode m = this.dw.getMethod("CalculadoraMain.main(java.lang.String[])");
 		Set<ClassNode> usedBy = m.getCalleeClasses();
-		assertEquals(6,usedBy.size());
-		assertTrue(usedBy.contains(this.dw.getClass("CalculadoraMain")));
-		assertTrue(usedBy.contains(this.dw.getClass("Logica")));
+		Assert.assertEquals(6,usedBy.size());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("CalculadoraMain")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Logica")));
 		
 		clazz = this.dw.getClass("CalculadoraMain");
 		usedBy = clazz.getCalleeClasses();
-		assertEquals(7,usedBy.size());
-		assertTrue(usedBy.contains(this.dw.getClass("CalculadoraMain")));
-		assertTrue(usedBy.contains(this.dw.getClass("Logica")));
+		Assert.assertEquals(7,usedBy.size());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("CalculadoraMain")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Logica")));
 		
 		clazz = this.dw.getClass("CalculadoraPolinomial");
 		usedBy = clazz.getCalleeClasses();
-		assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
-		assertEquals(5,usedBy.size());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
+		Assert.assertEquals(5,usedBy.size());
 		
 		clazz = this.dw.getClass("Comando");
 		usedBy = clazz.getCalleeClasses();
-		assertTrue(usedBy.contains(this.dw.getClass("Comando")));
-		assertEquals(5,usedBy.size());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Comando")));
+		Assert.assertEquals(5,usedBy.size());
 		
 		clazz = this.dw.getClass("IF");
 		usedBy = clazz.getCalleeClasses();
-		assertEquals(0,usedBy.size());
+		Assert.assertEquals(0,usedBy.size());
 		
 		clazz = this.dw.getClass("Inteiro");
 		usedBy = clazz.getCalleeClasses();
-		assertEquals(5,usedBy.size());
+		Assert.assertEquals(5,usedBy.size());
 		
 		clazz = this.dw.getClass("Logica");
 		usedBy = clazz.getCalleeClasses();
-		assertTrue(usedBy.contains(this.dw.getClass("TratamentosComuns")));
-		assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
-		assertTrue(usedBy.contains(this.dw.getClass("Logica")));
-		assertTrue(usedBy.contains(this.dw.getClass("Comando")));
-		assertTrue(usedBy.contains(this.dw.getClass("CalculadoraPolinomial")));
-		assertEquals(20,usedBy.size());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("TratamentosComuns")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Logica")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Comando")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("CalculadoraPolinomial")));
+		Assert.assertEquals(20,usedBy.size());
 		
 		clazz = this.dw.getClass("Polinomio");
 		usedBy = clazz.getCalleeClasses();
-		assertTrue(usedBy.contains(this.dw.getClass("TratamentosComuns")));
-		assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
-		assertTrue(usedBy.contains(this.dw.getClass("Inteiro")));
-		assertTrue(usedBy.contains(this.dw.getClass("Logica")));
-		assertEquals(13,usedBy.size());
-		
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("TratamentosComuns")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Polinomio")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Inteiro")));
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("Logica")));
+		Assert.assertEquals(13,usedBy.size());
 		
 		clazz = this.dw.getClass("TratamentosComuns");
 		usedBy = clazz.getCalleeClasses();
-		assertFalse(usedBy.isEmpty());
+		Assert.assertFalse(usedBy.isEmpty());
 		
 		clazz = this.dw.getClass("pacote.outro.Teste");
 		usedBy = clazz.getCalleeClasses();
-		assertFalse(usedBy.isEmpty());
+		Assert.assertFalse(usedBy.isEmpty());
 
 		clazz = this.dw.getClass("pacote.ClasseDentroDoPacote");
 		usedBy = clazz.getCalleeClasses();
 		
-		assertTrue(usedBy.contains(this.dw.getClass("pacote.outro.Teste")));
-		assertEquals(2,usedBy.size());
-		assertFalse(usedBy.isEmpty());
+		Assert.assertTrue(usedBy.contains(this.dw.getClass("pacote.outro.Teste")));
+		Assert.assertEquals(2,usedBy.size());
+		Assert.assertFalse(usedBy.isEmpty());
 	}
 	
+	@Test
 	public void testGetAllClasses() throws IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"edados1.jar");
-		assertEquals(10,dw.getAllClasses().size());
+		Assert.assertEquals(10,dw.getAllClasses().size());
 	}
 	
-	
+	@Test
 	public void testInnerClass() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"innerclass-relations.jar");
 		ClassNode clazz = this.dw.getClass("Logica.Polinomio$Monomio");
 		
 		Set<ClassNode> innerusers = clazz.getCallerClasses();
-		assertEquals(2,innerusers.size());
-		assertTrue(innerusers.contains(this.dw.getClass("Logica.Polinomio$Monomio")));
-		assertTrue(innerusers.contains(this.dw.getClass("Logica.Polinomio")));
+		Assert.assertEquals(2,innerusers.size());
+		Assert.assertTrue(innerusers.contains(this.dw.getClass("Logica.Polinomio$Monomio")));
+		Assert.assertTrue(innerusers.contains(this.dw.getClass("Logica.Polinomio")));
 	
 		Set<ClassNode> innerUse = clazz.getCalleeClasses();
-		assertEquals(8,innerUse.size());
-		assertTrue(innerUse.contains(this.dw.getClass("Logica.Polinomio$Monomio")));
-		
+		Assert.assertEquals(8,innerUse.size());
+		Assert.assertTrue(innerUse.contains(this.dw.getClass("Logica.Polinomio$Monomio")));
 	}
-	
+
+	@Test
 	public void testGetConstructors() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"constructors.jar");
 		ClassNode entity = this.dw.getClass("MultiplyConstructors");
 		Set<MethodNode> constructors = entity.getConstructors();
 		
-		assertEquals(4,constructors.size());
+		Assert.assertEquals(4,constructors.size());
 		MethodNode method = this.dw.getMethod("MultiplyConstructors.<init>()");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		method = this.dw.getMethod("MultiplyConstructors.<init>(double)");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		method = this.dw.getMethod("MultiplyConstructors.<init>(int)");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		method = this.dw.getMethod("MultiplyConstructors.<init>(float)");
-		assertTrue(constructors.contains(method));
-		
+		Assert.assertTrue(constructors.contains(method));
 		
 		/**
 		 * Don not forget the default constructor.
 		 */
 		entity = this.dw.getClass("NoneConstructors");
 		constructors = entity.getConstructors();
-		assertEquals(1,constructors.size());
+		Assert.assertEquals(1,constructors.size());
 		method = this.dw.getMethod("NoneConstructors.<init>()");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		entity = this.dw.getClass("PackageConstructor");
 		constructors = entity.getConstructors();
-		assertEquals(1,constructors.size());
+		Assert.assertEquals(1,constructors.size());
 		method = this.dw.getMethod("PackageConstructor.<init>()");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		entity = this.dw.getClass("PrivateConstructor");
 		constructors = entity.getConstructors();
-		assertEquals(1,constructors.size());
+		Assert.assertEquals(1,constructors.size());
 		method = this.dw.getMethod("PrivateConstructor.<init>()");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 		
 		entity = this.dw.getClass("PublicConstructor");
 		constructors = entity.getConstructors();
-		assertEquals(1,constructors.size());
+		Assert.assertEquals(1,constructors.size());
 		method = this.dw.getMethod("PublicConstructor.<init>(int)");
-		assertTrue(constructors.contains(method));
+		Assert.assertTrue(constructors.contains(method));
 	}
 	
+	@Test
 	public void testClassesWithRegularExpressions() throws InexistentEntityException {
-		
 		// Testa o retorno das classes que cont�m a string "api"
 		Set<ClassNode> classesThatContainsApi = dw.getClasses(".*api.*");
-		assertFalse(classesThatContainsApi.isEmpty());
-		assertTrue(classesThatContainsApi.contains(dw.getClass("org.designwizard.api.DesignWizard")));
-		assertTrue(classesThatContainsApi.contains(dw.getClass("org.designwizard.api.util.FileUtil")));
-		assertTrue(classesThatContainsApi.size() == 2);
+		Assert.assertFalse(classesThatContainsApi.isEmpty());
+		Assert.assertTrue(classesThatContainsApi.contains(dw.getClass("org.designwizard.api.DesignWizard")));
+		Assert.assertTrue(classesThatContainsApi.contains(dw.getClass("org.designwizard.api.util.FileUtil")));
+		Assert.assertTrue(classesThatContainsApi.size() == 2);
 		
 		// Testa o retorno das classes que terminam com a string "Wizard"
 		Set<ClassNode> classesFinishWithApi = dw.getClasses(".*Wizard$");
-		assertFalse(classesFinishWithApi.isEmpty());
-		assertTrue(classesFinishWithApi.contains(dw.getClass("org.designwizard.api.DesignWizard")));
-		assertTrue(classesFinishWithApi.size() == 1);
+		Assert.assertFalse(classesFinishWithApi.isEmpty());
+		Assert.assertTrue(classesFinishWithApi.contains(dw.getClass("org.designwizard.api.DesignWizard")));
+		Assert.assertTrue(classesFinishWithApi.size() == 1);
 				
 		// Testa o retorno das classes que iniciam com a string "api"
 		Set<ClassNode> classesStartingWithApi = dw.getClasses("^api.*");
-		assertTrue(classesStartingWithApi.isEmpty());
+		Assert.assertTrue(classesStartingWithApi.isEmpty());
 		
 		// Testa o retorno das classes que cont�m a string "common" ou "factory"
 		Set<ClassNode> classesThatContainsCommonOrFactory = dw.getClasses(".*common.*|.*factory.*");
-		assertFalse(classesThatContainsCommonOrFactory.isEmpty());
-		assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.design.factory.ElementsFactory")));
-		assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.design.factory.AbstractElementsFactory")));
-		assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.common.Config")));
-		assertTrue(classesThatContainsCommonOrFactory.size() == 3);
-	}
-	
+		Assert.assertFalse(classesThatContainsCommonOrFactory.isEmpty());
+		Assert.assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.design.factory.ElementsFactory")));
+		Assert.assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.design.factory.AbstractElementsFactory")));
+		Assert.assertTrue(classesThatContainsCommonOrFactory.contains(dw.getClass("org.designwizard.common.Config")));
+		Assert.assertTrue(classesThatContainsCommonOrFactory.size() == 3);
+	}	
 }

--- a/src_tests/tests/org/designwizard/design/EntityTest.java
+++ b/src_tests/tests/org/designwizard/design/EntityTest.java
@@ -2,84 +2,87 @@ package tests.org.designwizard.design;
 
 import java.io.File;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.Entity;
 import org.designwizard.design.Modifier;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class EntityTest extends TestCase {
+public class EntityTest {
 	
 private DesignWizard dw;
 	
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"visibility.jar");
 	}
 	
+	@Test
 	public void testVisibilityOfClasses() throws InexistentEntityException{
 		 
 		Entity entity = this.dw.getClass("PackageClass");
-		assertEquals(entity.getVisibility(), Modifier.PACKAGE);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PACKAGE);
 	
 		entity = this.dw.getClass("PublicClass");
-		assertEquals(entity.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PUBLIC);
 		
 		entity = this.dw.getClass("PublicClass$privateClass");
-		assertEquals(entity.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PRIVATE);
 		
 		entity = this.dw.getClass("PublicClass$PackageInternalClass");
-		assertEquals(entity.getVisibility(), Modifier.PACKAGE);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PACKAGE);
 		
 		entity = this.dw.getClass("PackageClass$PrivateClass");
-		assertEquals(entity.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PRIVATE);
 		
 		entity = this.dw.getClass("PackageClass$PublicInternalClass");
-		assertEquals(entity.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(entity.getVisibility(), Modifier.PUBLIC);
 		
 	}
 	
+	@Test
 	public void testVisibilityOfMethods() throws InexistentEntityException{
 		
 		Entity method = this.dw.getMethod("PrivateMethods.getint()");
-		assertEquals(method.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(method.getVisibility(), Modifier.PRIVATE);
 		
 		method = this.dw.getMethod("PrivateMethods.morePrivate()");
-		assertEquals(method.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(method.getVisibility(), Modifier.PRIVATE);
 		
 		method = this.dw.getMethod("ProtectedMethods.X()");
-		assertEquals(method.getVisibility(), Modifier.PROTECTED);
+		Assert.assertEquals(method.getVisibility(), Modifier.PROTECTED);
 		
 		method = this.dw.getMethod("ProtectedMethods.X1()");
-		assertEquals(method.getVisibility(), Modifier.PROTECTED);
+		Assert.assertEquals(method.getVisibility(), Modifier.PROTECTED);
 
 		method = this.dw.getMethod("PublicMethods.main(java.lang.String[])");
-		assertEquals(method.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(method.getVisibility(), Modifier.PUBLIC);
 
 		method = this.dw.getMethod("PublicMethods.returnInt()");
-		assertEquals(method.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(method.getVisibility(), Modifier.PUBLIC);
 	}
 	
+	@Test
 	public void testVisibilityOfFields() throws InexistentEntityException{
 		
 		Entity field = this.dw.getField("PrivateFields.ps");
-		assertEquals(field.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(field.getVisibility(), Modifier.PRIVATE);
 		
 		field = this.dw.getField("PrivateFields.x");
-		assertEquals(field.getVisibility(), Modifier.PRIVATE);
+		Assert.assertEquals(field.getVisibility(), Modifier.PRIVATE);
 		
 		field = this.dw.getField("ProtectedFields.x");
-		assertEquals(field.getVisibility(), Modifier.PROTECTED);
+		Assert.assertEquals(field.getVisibility(), Modifier.PROTECTED);
 		
 		field = this.dw.getField("ProtectedFields.ps");
-		assertEquals(field.getVisibility(), Modifier.PROTECTED);
+		Assert.assertEquals(field.getVisibility(), Modifier.PROTECTED);
 		
 		field = this.dw.getField("PublicFields.x");
-		assertEquals(field.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(field.getVisibility(), Modifier.PUBLIC);
 		
 		field = this.dw.getField("PublicFields.ps");
-		assertEquals(field.getVisibility(), Modifier.PUBLIC);
+		Assert.assertEquals(field.getVisibility(), Modifier.PUBLIC);
 	}
-
 }

--- a/src_tests/tests/org/designwizard/design/FieldNodeTest.java
+++ b/src_tests/tests/org/designwizard/design/FieldNodeTest.java
@@ -3,8 +3,6 @@ package tests.org.designwizard.design;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.common.Config;
 import org.designwizard.design.ClassNode;
@@ -13,13 +11,16 @@ import org.designwizard.design.FieldNode;
 import org.designwizard.design.factory.ElementsFactory;
 import org.designwizard.design.relation.Relation.TypesOfRelation;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class FieldNodeTest extends TestCase {
+public class FieldNodeTest {
 	
 	private static final String DESIGNWIZARD_DIR = "classes";
 	
 	private DesignWizard dw;
 	
+	@Test
 	public void testGetDeclaredType() throws InexistentEntityException {
 		String fieldName = "Class.fieldName";
 		String className = "int";
@@ -30,52 +31,55 @@ public class FieldNodeTest extends TestCase {
 		design.addRelation(TypesOfRelation.CONTAINS, "MyClass", "F:"+fieldName );
 		
 		FieldNode field = design.getField(fieldName);
-		assertFalse(field.isStatic());
+		Assert.assertFalse(field.isStatic());
 		ClassNode declaredType = design.getClass(className);
 		ClassNode parentClass = design.getClass(parentClassName);
 		
-		assertEquals(field.getType(), declaredType);
-		assertEquals(field.getDeclaringClass(), parentClass);
+		Assert.assertEquals(field.getType(), declaredType);
+		Assert.assertEquals(field.getDeclaringClass(), parentClass);
 	}
 	
+	@Test
 	public void testGetShortName() throws InexistentEntityException {
 		String fieldName = "Class.fieldName";
 		String className = "int";
 		Design design = new Design();
 		design.addRelation(TypesOfRelation.INSTANCE, "F:"+fieldName, className);
 		FieldNode field = design.getField(fieldName);
-		assertEquals("fieldName",field.getShortName());
+		Assert.assertEquals("fieldName",field.getShortName());
 	}
 	
+	@Test
 	public void testIsStatic() throws IOException, InexistentEntityException {
 		DesignWizard dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"singleton.jar");
 		FieldNode field = dw.getField("SingletonImplementation.uniqueInstance");
-		assertTrue(field.isStatic());
+		Assert.assertTrue(field.isStatic());
 	}
 	
+	@Test
 	public void testGetPackageName() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 		
 		ClassNode classNode = this.dw.getClass(Config.class);
 		for (FieldNode field : classNode.getAllFields()) {
-			assertEquals("org.designwizard.common", field.getPackage().getName());
+			Assert.assertEquals("org.designwizard.common", field.getPackage().getName());
 		}
 		
 		classNode = this.dw.getClass(ElementsFactory.class);
 		for (FieldNode field : classNode.getAllFields()) {
-			assertEquals("org.designwizard.design.factory", field.getPackage().getName());
+			Assert.assertEquals("org.designwizard.design.factory", field.getPackage().getName());
 		}
 		
 		classNode = this.dw.getClass(ClassNodeTest.class);
 		for (FieldNode field : classNode.getAllFields()) {
-			assertEquals("tests.org.designwizard.design", field.getPackage().getName());
+			Assert.assertEquals("tests.org.designwizard.design", field.getPackage().getName());
 		}
 		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"visibility.jar");
 		classNode = this.dw.getClass("PrivateFields");
 		for (FieldNode field : classNode.getAllFields()) {
 			//default package
-			assertEquals("default", field.getPackage().getName());
+			Assert.assertEquals("default", field.getPackage().getName());
 		}
 	}
 	

--- a/src_tests/tests/org/designwizard/design/InheritanceTest.java
+++ b/src_tests/tests/org/designwizard/design/InheritanceTest.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.Design;
@@ -13,21 +11,23 @@ import org.designwizard.design.FieldNode;
 import org.designwizard.design.MethodNode;
 import org.designwizard.design.relation.Relation.TypesOfRelation;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
 
 //FIXME not a unit test
-public class InheritanceTest extends TestCase {
+public class InheritanceTest {
 
 	private DesignWizard dw;
 
-	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		// TODO Auto-generated method stub
-		super.tearDown();
 		dw = null;
 	}
 
+	@Test
 	public void testInheritance() throws InexistentEntityException {
-
 		Design design = new Design();
 		design.addRelation(TypesOfRelation.EXTENDS, "SuperClass", "java.lang.Object");
 		design.addRelation(TypesOfRelation.EXTENDS, "SubClass", "SuperClass");
@@ -40,22 +40,22 @@ public class InheritanceTest extends TestCase {
 
 		ClassNode subClass = design.getClass("SubClass");
 		Set<FieldNode> declaredFields = subClass.getDeclaredFields();
-		assertTrue(declaredFields.isEmpty());
+		Assert.assertTrue(declaredFields.isEmpty());
 		Set<FieldNode> inheritedFields = subClass.getInheritedFields();
-		assertEquals(1, inheritedFields.size());
-
+		Assert.assertEquals(1, inheritedFields.size());
 
 		Set<FieldNode> inheritedField = design.getClass("SubClass").getInheritedFields();
-		assertEquals("SuperClass.id", inheritedField.iterator().next().getName());
+		Assert.assertEquals("SuperClass.id", inheritedField.iterator().next().getName());
 
 		MethodNode methodNode = design.getMethod("SubClass.getID()");
 
-		assertEquals(methodNode.getAccessedFields().size(), 1);
+		Assert.assertEquals(methodNode.getAccessedFields().size(), 1);
 
-		assertEquals("F:SuperClass.id", "F:"+methodNode.getAccessedFields().iterator().next().getName());
-		assertFalse(design.getField("SuperClass.id").getCallerMethods().isEmpty());
+		Assert.assertEquals("F:SuperClass.id", "F:"+methodNode.getAccessedFields().iterator().next().getName());
+		Assert.assertFalse(design.getField("SuperClass.id").getCallerMethods().isEmpty());
 	}
 
+	@Test
 	public void testDesignWizardInheritance() throws IOException, InexistentEntityException {
 		dw = new DesignWizard("classes");
 
@@ -63,28 +63,29 @@ public class InheritanceTest extends TestCase {
 		Set<FieldNode> accessedFields = method.getAccessedFields();
 
 		FieldNode field = dw.getField("org.designwizard.design.AbstractEntity.name");
-		assertTrue(accessedFields.contains(field));
+		Assert.assertTrue(accessedFields.contains(field));
 
 		field = dw.getField("org.designwizard.design.AbstractEntity.type");
-		assertTrue(accessedFields.contains(field));
+		Assert.assertTrue(accessedFields.contains(field));
 
 		field = dw.getField("org.designwizard.design.AbstractEntity.relations");
-		assertTrue(accessedFields.contains(field));
+		Assert.assertTrue(accessedFields.contains(field));
 
 		method = dw.getMethod("org.designwizard.design.AbstractEntity.getName()");
 		accessedFields = method.getAccessedFields();
 		field = dw.getField("org.designwizard.design.AbstractEntity.name");
-		assertTrue(accessedFields.contains(field));
+		Assert.assertTrue(accessedFields.contains(field));
 
 		method = dw.getMethod("org.designwizard.design.ClassNode.getShortName()");
 		Set<MethodNode> methods = method.getCalleeMethods();
-		assertFalse(methods.contains(dw.getMethod("org.designwizard.design.ClassNode.getName()")));
-		assertTrue(methods.contains(dw.getMethod("org.designwizard.design.AbstractEntity.getName()")));
-		assertTrue(methods.contains(dw.getMethod("org.designwizard.design.AbstractEntity.getShortName()")));
-		assertTrue(methods.contains(dw.getMethod("org.designwizard.design.ClassNode.isInnerClass()")));
-		assertEquals(6, methods.size());
+		Assert.assertFalse(methods.contains(dw.getMethod("org.designwizard.design.ClassNode.getName()")));
+		Assert.assertTrue(methods.contains(dw.getMethod("org.designwizard.design.AbstractEntity.getName()")));
+		Assert.assertTrue(methods.contains(dw.getMethod("org.designwizard.design.AbstractEntity.getShortName()")));
+		Assert.assertTrue(methods.contains(dw.getMethod("org.designwizard.design.ClassNode.isInnerClass()")));
+		Assert.assertEquals(6, methods.size());
 	}
 
+	@Test
 	public void testAttributeRedefinedBySubClass() throws IOException, InexistentEntityException {
 
 		/**
@@ -99,22 +100,22 @@ public class InheritanceTest extends TestCase {
 
 		ClassNode subClass = dw.getClass("SubClass");
 
-		assertEquals(subClass.getDeclaredFields().size(),1);
-		assertEquals(subClass.getInheritedFields().size(),3);
+		Assert.assertEquals(subClass.getDeclaredFields().size(),1);
+		Assert.assertEquals(subClass.getInheritedFields().size(),3);
 
 		MethodNode method = dw.getMethod("SubClass.<init>()");
 		Set<FieldNode> accessedFields = method.getAccessedFields();
-		assertEquals(4, accessedFields.size());
+		Assert.assertEquals(4, accessedFields.size());
 
 		FieldNode declaredField = dw.getField("SubClass.id");
-		assertEquals(subClass.getDeclaredFields().iterator().next(),declaredField);
-
+		Assert.assertEquals(subClass.getDeclaredFields().iterator().next(),declaredField);
 
 		ClassNode superClass = dw.getClass("SuperClass");
-		assertEquals(superClass.getDeclaredFields().size(),1);
-		assertEquals(superClass.getInheritedFields().size(),2);
+		Assert.assertEquals(superClass.getDeclaredFields().size(),1);
+		Assert.assertEquals(superClass.getInheritedFields().size(),2);
 	}
 
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers() throws IOException, InexistentEntityException {
 		/**
 		 * 1
@@ -123,22 +124,22 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Filha.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("FUser.metodo()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 
 		hasToBeThere = dw.getMethod("FUser.metodo()");
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 	}
 
-
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers2() throws IOException, InexistentEntityException {
 		/**
 		 * 2
@@ -147,37 +148,38 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Pai.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("FUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("FUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("FUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("PUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		assertEquals(5,callers.size());
+		Assert.assertEquals(5,callers.size());
 
 		hasToBeThere = dw.getMethod("FUser.metodo1()");
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 
 		hasToBeThere = dw.getMethod("PUser.metodo1()");
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("PUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 	}
 
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers3() throws IOException, InexistentEntityException {
 		/**
 		 * 3
@@ -186,16 +188,17 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Pai.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("Pai.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("Pai.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 	}
 
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers4() throws IOException, InexistentEntityException {
 		/**
 		 * 4.1
@@ -206,19 +209,19 @@ public class InheritanceTest extends TestCase {
 		Set<MethodNode> callersFirstLevel = field.getCallerMethods();
 
 		MethodNode hasToBeThere = dw.getMethod("Pai.<init>(java.lang.Object)");
-		assertTrue(callersFirstLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersFirstLevel.contains(hasToBeThere));
 		hasToBeThere = dw.getMethod("Pai.metodo1()");
-		assertTrue(callersFirstLevel.contains(hasToBeThere));
-		assertEquals(2, callersFirstLevel.size());
+		Assert.assertTrue(callersFirstLevel.contains(hasToBeThere));
+		Assert.assertEquals(2, callersFirstLevel.size());
 
 		Set<MethodNode> callersSecondLevel = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("Pai.metodo2()");
-		assertTrue(callersSecondLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersSecondLevel.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callersSecondLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersSecondLevel.contains(hasToBeThere));
 		
-		assertEquals(2, callersSecondLevel.size());
+		Assert.assertEquals(2, callersSecondLevel.size());
 
 		/**
 		 * 4.2
@@ -226,41 +229,43 @@ public class InheritanceTest extends TestCase {
 		field = dw.getField("Filha.A");
 		callersFirstLevel = field.getCallerMethods();
 		hasToBeThere = dw.getMethod("Filha.<init>(java.lang.String)");
-		assertTrue(callersFirstLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersFirstLevel.contains(hasToBeThere));
 
 		callersSecondLevel = hasToBeThere.getCallerMethods();
 
 		hasToBeThere = dw.getMethod("FUser.metodo2()");
-		assertTrue(callersSecondLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersSecondLevel.contains(hasToBeThere));
 
 		callersSecondLevel = hasToBeThere.getCallerMethods(); 
 		hasToBeThere = dw.getMethod("FUserUser.metodo2()");
-		assertTrue(callersSecondLevel.contains(hasToBeThere));
+		Assert.assertTrue(callersSecondLevel.contains(hasToBeThere));
 	}
 	
-	
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers5() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources/testFiles/commands/removecommandsubsupercase5.jar");
 		
 		MethodNode method = dw.getMethod("Pai.metodo3()");
 		Set<MethodNode> callersFirstLevel = method.getCallerMethods();
-		assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo4()")));
-		assertEquals(1, callersFirstLevel.size());
+		Assert.assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo4()")));
+		Assert.assertEquals(1, callersFirstLevel.size());
 	}
 	
+	@Test
 	public void testSubClassExtendsSuperClassAttributeCallers6() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources/testFiles/commands/removecommandsubsupercase6.jar");
 		
 		MethodNode method = dw.getMethod("Pai.metodo3()");
 		Set<MethodNode> callersFirstLevel = method.getCallerMethods();
 		
-		assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo3()")));
-		assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo4()")));
-		assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo5()")));
+		Assert.assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo3()")));
+		Assert.assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo4()")));
+		Assert.assertTrue(callersFirstLevel.contains(dw.getMethod("FUser.metodo5()")));
 
-		assertEquals(3, callersFirstLevel.size());
+		Assert.assertEquals(3, callersFirstLevel.size());
 	}
 	
+	@Test
 	public void testRemoveCommandSubAbs1() throws IOException, InexistentEntityException {
 		/**
 		 * 1
@@ -269,20 +274,21 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Filha.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("FUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2, callers.size());
+		Assert.assertEquals(2, callers.size());
 
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1, callers.size());
+		Assert.assertEquals(1, callers.size());
 	}
 
+	@Test
 	public void testRemoveCommandSubAbs2() throws IOException, InexistentEntityException {
 		/**
 		 * 2
@@ -291,55 +297,56 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Pai.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("FUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("FUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("PUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("Filha.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(5, callers.size());
+		Assert.assertEquals(5, callers.size());
 		
 		callers = dw.getMethod("FUser.metodo1()").getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1, callers.size());
+		Assert.assertEquals(1, callers.size());
 		
 		callers = dw.getMethod("PUser.metodo1()").getCallerMethods();
 		hasToBeThere = dw.getMethod("PUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1, callers.size());
+		Assert.assertEquals(1, callers.size());
 	}
 	
+	@Test
 	public void testRemoveCommandSubAbs3() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources/testFiles/commands/removecommandsubabscase3.jar");
 		FieldNode field = dw.getField("Pai.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("Pai.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("Pai.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 	}
 	
-	
+	@Test
 	public void testRemoveCommandSubAbs4() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources/testFiles/commands/removecommandsubsabscase4.jar");
 		
@@ -349,21 +356,21 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Pai.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("Pai.<init>(java.lang.Object)");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("Pai.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("Pai.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 		
 		/**
 		 * 1.2
@@ -371,19 +378,20 @@ public class InheritanceTest extends TestCase {
 		field = dw.getField("Filha.A");
 		callers = field.getCallerMethods();
 		hasToBeThere = dw.getMethod("Filha.<init>(java.lang.String)");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = this.dw.getMethod("FUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = this.dw.getMethod("FUserUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 	}
 	
+	@Test
 	public void testRemoveCommandAbsAbs1() throws IOException, InexistentEntityException {
 		/**
 		 * 1.1
@@ -392,22 +400,21 @@ public class InheritanceTest extends TestCase {
 		FieldNode field = dw.getField("Filha.A");
 		Set<MethodNode> callers = field.getCallerMethods();
 		MethodNode hasToBeThere = dw.getMethod("Filha.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		
 		hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("FUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
-		assertEquals(3,callers.size());
+		Assert.assertEquals(3,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo1()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 		
 		/**
 		 * 1.2
@@ -416,19 +423,20 @@ public class InheritanceTest extends TestCase {
 		callers = method.getCallerMethods();
 
 		hasToBeThere = this.dw.getMethod("PUser.metodo3()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
 		hasToBeThere = this.dw.getMethod("FUser.metodo6User()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = this.dw.getMethod("FUserUser.metodo6UserUser()");
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 	}
 	
+	@Test
 	public void testRemoveCommandSubInt1() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard("resources/testFiles/commands/removecommandasubintcase1.jar");
 		
@@ -439,19 +447,18 @@ public class InheritanceTest extends TestCase {
 		Set<MethodNode> callers = field.getCallerMethods();
 
 		MethodNode hasToBeThere = dw.getMethod("PUser.metodo2()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = dw.getMethod("FUser.metodo()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = dw.getMethod("FUserUser.metodo()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
-		
+		Assert.assertEquals(1,callers.size());
 		
 		/**
 		 * 1.2
@@ -459,20 +466,17 @@ public class InheritanceTest extends TestCase {
 		MethodNode method = dw.getMethod("Filha.metodo6()");
 		callers = method.getCallerMethods();
 		hasToBeThere = this.dw.getMethod("PUser.metodo5()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 
 		hasToBeThere = this.dw.getMethod("FUser.metodo6User()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(2,callers.size());
+		Assert.assertEquals(2,callers.size());
 		
 		callers = hasToBeThere.getCallerMethods();
 		hasToBeThere = this.dw.getMethod("FUserUser.metodo6UserUser()");
-		assertTrue(callers.contains(hasToBeThere));
+		Assert.assertTrue(callers.contains(hasToBeThere));
 		
-		assertEquals(1,callers.size());
+		Assert.assertEquals(1,callers.size());
 	}
-	
-	
-	
 }

--- a/src_tests/tests/org/designwizard/design/InternalClassExtractionTest.java
+++ b/src_tests/tests/org/designwizard/design/InternalClassExtractionTest.java
@@ -2,22 +2,23 @@ package tests.org.designwizard.design;
 
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class InternalClassExtractionTest extends TestCase {
+public class InternalClassExtractionTest {
 	
 	private DesignWizard dw;
 	
-	@Override
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.dw = new DesignWizard("resources/testFiles/innerclass.jar");
 	}
 	
-	
+	@Test
 	public void testInternalClasses() throws InexistentEntityException {
 		
 		ClassNode classNode = this.dw.getClass("ClassTest");
@@ -28,18 +29,17 @@ public class InternalClassExtractionTest extends TestCase {
 		
 		Set<ClassNode> innerClasses = classNode.getInnerClasses();
 		
-		assertTrue(innerClasses.contains(privateInner));
-		assertTrue(innerClasses.contains(protectedInner));
-		assertTrue(innerClasses.contains(publicInner));
-		assertTrue(innerClasses.contains(packageInner));
+		Assert.assertTrue(innerClasses.contains(privateInner));
+		Assert.assertTrue(innerClasses.contains(protectedInner));
+		Assert.assertTrue(innerClasses.contains(publicInner));
+		Assert.assertTrue(innerClasses.contains(packageInner));
 		
 		// existe uma classe anonima
-		assertEquals(5, innerClasses.size());
+		Assert.assertEquals(5, innerClasses.size());
 
-		assertEquals(privateInner.getOuterClass(), classNode);
-		assertEquals(publicInner.getOuterClass(), classNode);
-		assertEquals(protectedInner.getOuterClass(), classNode);
-		assertEquals(packageInner.getOuterClass(), classNode);
-		
+		Assert.assertEquals(privateInner.getOuterClass(), classNode);
+		Assert.assertEquals(publicInner.getOuterClass(), classNode);
+		Assert.assertEquals(protectedInner.getOuterClass(), classNode);
+		Assert.assertEquals(packageInner.getOuterClass(), classNode);
 	}
 }

--- a/src_tests/tests/org/designwizard/design/MethodNodeTest.java
+++ b/src_tests/tests/org/designwizard/design/MethodNodeTest.java
@@ -5,8 +5,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.common.Config;
 import org.designwizard.design.ClassNode;
@@ -15,322 +13,319 @@ import org.designwizard.design.Modifier;
 import org.designwizard.design.factory.AbstractElementsFactory;
 import org.designwizard.exception.InexistentEntityException;
 import org.designwizard.exception.InvalidTypeOfVisibility;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class MethodNodeTest extends TestCase {
+public class MethodNodeTest {
 	private DesignWizard dw;
 	private static final String DESIGNWIZARD_DIR = "classes";
 
+	@Test
 	public void testGetPackageName() throws IOException, InexistentEntityException {
 		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 
 		ClassNode classNode = this.dw.getClass(Config.class);
 		for (MethodNode method : classNode.getAllMethods()) {
-			assertEquals("org.designwizard.common", method.getPackage().getName());
+			Assert.assertEquals("org.designwizard.common", method.getPackage().getName());
 		}
 
 
 		classNode = this.dw.getClass(AbstractElementsFactory.class);
 		for (MethodNode method : classNode.getAllMethods()) {
-			assertEquals("org.designwizard.design.factory", method.getPackage().getName());
-		}
-
-
-		classNode = this.dw.getClass(ClassNodeTest.class);
-		for (MethodNode method : classNode.getAllMethods()) {
-			assertEquals("tests.org.designwizard.design", method.getPackage().getName());
+			Assert.assertEquals("org.designwizard.design.factory", method.getPackage().getName());
 		}
 
 		classNode = this.dw.getClass(ClassNodeTest.class);
 		for (MethodNode method : classNode.getAllMethods()) {
-			assertEquals("tests.org.designwizard.design", method.getPackage().getName());
+			Assert.assertEquals("tests.org.designwizard.design", method.getPackage().getName());
+		}
+
+		classNode = this.dw.getClass(ClassNodeTest.class);
+		for (MethodNode method : classNode.getAllMethods()) {
+			Assert.assertEquals("tests.org.designwizard.design", method.getPackage().getName());
 		}
 
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"visibility.jar");
 		classNode = this.dw.getClass("PackageClass");
 		for (MethodNode method : classNode.getAllMethods()) {
-			assertEquals("default", method.getPackage().getName());
+			Assert.assertEquals("default", method.getPackage().getName());
 		}
 	}
 
+	@Test
 	public void testGetShortName() throws IOException, InexistentEntityException {
-
 		DesignWizard dw = new DesignWizard("classes");
 		MethodNode method = dw.getMethod("org.designwizard.design.AbstractEntity.getShortName()");
-		assertEquals("getShortName()",method.getShortName());
-		assertEquals(method.getShortName(), method.getShortName());
+		Assert.assertEquals("getShortName()",method.getShortName());
+		Assert.assertEquals(method.getShortName(), method.getShortName());
 		
 		method = dw.getMethod("org.designwizard.design.Entity.addModifier(org.designwizard.design.Modifier)");
-		assertEquals("addModifier(org.designwizard.design.Modifier)",method.getShortName());
-		
+		Assert.assertEquals("addModifier(org.designwizard.design.Modifier)",method.getShortName());
 	}
 
+	@Test
 	public void testReturnMethod() throws InexistentEntityException, IOException {
-		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"returnmethod.jar");
 
 		MethodNode method = this.dw.getMethod("AllMethod.voidReturn()");
-		assertEquals("void",method.getReturnType().getName());
+		Assert.assertEquals("void",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.intReturn()");
-		assertEquals("int",method.getReturnType().getName());
+		Assert.assertEquals("int",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.byteReturn()");
-		assertEquals("byte",method.getReturnType().getName());
+		Assert.assertEquals("byte",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.charReturn()");
-		assertEquals("char",method.getReturnType().getName());
+		Assert.assertEquals("char",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.booleanReturn()");
-		assertEquals("boolean",method.getReturnType().getName());
+		Assert.assertEquals("boolean",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.doubleReturn()");
-		assertEquals("double",method.getReturnType().getName());
+		Assert.assertEquals("double",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.floatReturn()");
-		assertEquals("float",method.getReturnType().getName());
+		Assert.assertEquals("float",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.longReturn()");
-		assertEquals("long",method.getReturnType().getName());
+		Assert.assertEquals("long",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.typeReturn()");
-		assertEquals("java.lang.Object",method.getReturnType().getName());
-
+		Assert.assertEquals("java.lang.Object",method.getReturnType().getName());
 
 		// array of one dimension
 		method = this.dw.getMethod("AllMethod.intArrayReturn()");
-		assertEquals("int[]",method.getReturnType().getName());
+		Assert.assertEquals("int[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.byteArrayReturn()");
-		assertEquals("byte[]",method.getReturnType().getName());
+		Assert.assertEquals("byte[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.charArrayReturn()");
-		assertEquals("char[]",method.getReturnType().getName());
+		Assert.assertEquals("char[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.booleanArrayReturn()");
-		assertEquals("boolean[]",method.getReturnType().getName());
+		Assert.assertEquals("boolean[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.doubleArrayReturn()");
-		assertEquals("double[]",method.getReturnType().getName());
+		Assert.assertEquals("double[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.floatArrayReturn()");
-		assertEquals("float[]",method.getReturnType().getName());
+		Assert.assertEquals("float[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.longArrayReturn()");
-		assertEquals("long[]",method.getReturnType().getName());
+		Assert.assertEquals("long[]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.typeArrayReturn()");
-		assertEquals("java.lang.Object[]",method.getReturnType().getName());
-
+		Assert.assertEquals("java.lang.Object[]",method.getReturnType().getName());
 
 		// array of 2 dimensions
 		method = this.dw.getMethod("AllMethod.int2ArrayReturn()");
-		assertEquals("int[][]",method.getReturnType().getName());
+		Assert.assertEquals("int[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.byte2ArrayReturn()");
-		assertEquals("byte[][]",method.getReturnType().getName());
+		Assert.assertEquals("byte[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.char2ArrayReturn()");
-		assertEquals("char[][]",method.getReturnType().getName());
+		Assert.assertEquals("char[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.boolean2ArrayReturn()");
-		assertEquals("boolean[][]",method.getReturnType().getName());
+		Assert.assertEquals("boolean[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.double2ArrayReturn()");
-		assertEquals("double[][]",method.getReturnType().getName());
+		Assert.assertEquals("double[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.float2ArrayReturn()");
-		assertEquals("float[][]",method.getReturnType().getName());
+		Assert.assertEquals("float[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.long2ArrayReturn()");
-		assertEquals("long[][]",method.getReturnType().getName());
+		Assert.assertEquals("long[][]",method.getReturnType().getName());
 
 		method = this.dw.getMethod("AllMethod.type2ArrayReturn()");
-		assertEquals("java.lang.Object[][]",method.getReturnType().getName());
-	
+		Assert.assertEquals("java.lang.Object[][]",method.getReturnType().getName());
 	}
 
-
+	@Test
 	public void testMainThrows() throws InexistentEntityException, IOException {
-		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"throws.jar");
 		MethodNode method = this.dw.getMethod("Throws.main(java.lang.String[])");
 		Set<ClassNode> exceptions = method.getThrownExceptions();
 		ClassNode classEntity = this.dw.getClass(IOException.class);
-		assertTrue(exceptions.contains(classEntity));
+		Assert.assertTrue(exceptions.contains(classEntity));
 		classEntity = this.dw.getClass(FileNotFoundException.class);
-		assertTrue(exceptions.contains(classEntity));
-		assertTrue(exceptions.size() == 2);
-	
+		Assert.assertTrue(exceptions.contains(classEntity));
+		Assert.assertTrue(exceptions.size() == 2);
 	}
 
+	@Test
 	public void testThrowsNothing() throws Exception {
-	
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"throws.jar");
 		MethodNode method = this.dw.getMethod("Throws.throwsNothing()");
 		Set<ClassNode> exceptions = method.getThrownExceptions();
-		assertEquals(exceptions.size(),0);
-	
+		Assert.assertEquals(exceptions.size(),0);
 	}
 
+	@Test
 	public void testThrowsException() throws Exception {
-		
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"throws.jar");
 		MethodNode method = this.dw.getMethod("Throws.throwsException()");
 		Set<ClassNode> exceptions = method.getThrownExceptions();
 		ClassNode classEntity = this.dw.getClass(Exception.class);
-		assertTrue(exceptions.contains(classEntity));
-		assertEquals(exceptions.size(),1);
-	
+		Assert.assertTrue(exceptions.contains(classEntity));
+		Assert.assertEquals(exceptions.size(),1);
 	}
 	
+	@Test
 	public void testReturn() throws IOException, InexistentEntityException {
-	
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"returnmethod.jar");
 		
 		ClassNode clazz = this.dw.getClass("AllMethod");
 		
 		Set<MethodNode> returnSet = clazz.getAllMethodsThatReturn("void");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("int");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("short");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("byte");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("char");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("boolean");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("double");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("float");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("long");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("java.lang.Object");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn(Object.class.getName());
-		assertEquals(returnSet.size() , 1);
-		
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("int[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("byte[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("short[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("char[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("boolean[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("double[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("float[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("long[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("java.lang.Object[]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("int[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("byte[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("char[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("boolean[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("double[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("float[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("long[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 		
 		returnSet = clazz.getAllMethodsThatReturn("short[][]");
-		assertEquals(returnSet.size() , 1);
+		Assert.assertEquals(returnSet.size() , 1);
 				
 		returnSet = clazz.getAllMethodsThatReturn("java.lang.Object[][]");
-		assertEquals(returnSet.size() , 1);
-	
+		Assert.assertEquals(returnSet.size() , 1);
 	}
 	
+	@Test
 	public void testGetAllMethodsWithVisibility() throws IOException, InvalidTypeOfVisibility, InexistentEntityException {
-	
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"accessmodifiers.jar");
 		
 		MethodNode method = this.dw.getMethod("AccessModifiers.pub()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("AccessModifiers.pus(java.lang.String[])");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("AccessModifiers.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("MorePackage.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("MorePrivate.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("MorePrivate.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("MoreProtected.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PUBLIC));
 		
 		method = this.dw.getMethod("MorePublic.<init>()");
-		assertTrue(method.getModifiers().contains(Modifier.PRIVATE));
+		Assert.assertTrue(method.getModifiers().contains(Modifier.PRIVATE));
 	}
 	
+	@Test
 	public void testMethodsWithRegularExpressions() throws InexistentEntityException, IOException {
-			this.dw = new DesignWizard(DESIGNWIZARD_DIR);
+		this.dw = new DesignWizard(DESIGNWIZARD_DIR);
 		
-			// Testa o retorno das method que contém a string "get"
-			Set<MethodNode> methodThatCointainsGet = dw.getMethods(".*get.*");
-			assertFalse("Expected False but came True",methodThatCointainsGet.isEmpty());
-			assertTrue(methodThatCointainsGet.contains(dw.getMethod("org.designwizard.design.Entity.getClassNode()")));
-			assertTrue(methodThatCointainsGet.contains(dw.getMethod("org.designwizard.design.PackageNode.getAllMethods()")));
-			assertTrue(methodThatCointainsGet.size() == 189);
-			
-			// Testa o retorno das method que terminam com a string "String)"
-			Set<MethodNode> methodsFinishingWithParenteses = dw.getMethods(".*(String(\\W))$");
-			assertFalse(methodsFinishingWithParenteses.isEmpty());
-			assertTrue(methodsFinishingWithParenteses.contains(dw.getMethod("org.designwizard.design.Design.packageExtracted(java.lang.String)")));
-			assertTrue(methodsFinishingWithParenteses.size() == 125);
-					
-			// Testa o retorno das method que contém a string "get" ou ".set"
-			Set<MethodNode> methodsThatContainsGetOrSet = dw.getMethods(".*get.*|.*(\\W)set.*");
-			assertFalse(methodsThatContainsGetOrSet.isEmpty());
-			assertTrue(methodsThatContainsGetOrSet.contains(dw.getMethod("org.designwizard.design.Design.setReturnType(java.lang.String,java.lang.String)")));
-			assertTrue(methodsThatContainsGetOrSet.contains(dw.getMethod("org.designwizard.design.PackageNode.getAllMethods()")));
-			assertFalse(methodsThatContainsGetOrSet.contains(dw.getMethod("org.designwizard.api.util.FileUtil.reset()")));
-			assertTrue(methodsThatContainsGetOrSet.size() == 218);
+		// Testa o retorno das method que contém a string "get"
+		Set<MethodNode> methodThatCointainsGet = dw.getMethods(".*get.*");
+		Assert.assertFalse("Expected False but came True", methodThatCointainsGet.isEmpty());
+		Assert.assertTrue(
+				methodThatCointainsGet.contains(dw.getMethod("org.designwizard.design.Entity.getClassNode()")));
+		Assert.assertTrue(
+				methodThatCointainsGet.contains(dw.getMethod("org.designwizard.design.PackageNode.getAllMethods()")));
+		Assert.assertTrue(methodThatCointainsGet.size() == 189);
+
+		// Testa o retorno das method que terminam com a string "String)"
+		Set<MethodNode> methodsFinishingWithParenteses = dw.getMethods(".*(String(\\W))$");
+		Assert.assertFalse(methodsFinishingWithParenteses.isEmpty());
+		Assert.assertTrue(methodsFinishingWithParenteses
+				.contains(dw.getMethod("org.designwizard.design.Design.packageExtracted(java.lang.String)")));
+		Assert.assertTrue(methodsFinishingWithParenteses.size() == 125);
+
+		// Testa o retorno das method que contém a string "get" ou ".set"
+		Set<MethodNode> methodsThatContainsGetOrSet = dw.getMethods(".*get.*|.*(\\W)set.*");
+		Assert.assertFalse(methodsThatContainsGetOrSet.isEmpty());
+		Assert.assertTrue(methodsThatContainsGetOrSet.contains(
+				dw.getMethod("org.designwizard.design.Design.setReturnType(java.lang.String,java.lang.String)")));
+		Assert.assertTrue(methodsThatContainsGetOrSet
+				.contains(dw.getMethod("org.designwizard.design.PackageNode.getAllMethods()")));
+		Assert.assertFalse(methodsThatContainsGetOrSet.contains(dw.getMethod("org.designwizard.api.util.FileUtil.reset()")));
+		Assert.assertTrue(methodsThatContainsGetOrSet.size() == 218);
 	}	
-	
 }

--- a/src_tests/tests/org/designwizard/design/PackageExtractionTest.java
+++ b/src_tests/tests/org/designwizard/design/PackageExtractionTest.java
@@ -3,118 +3,103 @@ package tests.org.designwizard.design;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.MethodNode;
 import org.designwizard.design.PackageNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class PackageExtractionTest extends TestCase {
+public class PackageExtractionTest {
 	
 	private DesignWizard dw;
 	
-	@Override
-	protected void setUp() throws IOException {
-	
+	@Before
+	public void setUp() throws IOException {
 		dw = new DesignWizard("classes");
-	
 	}
 	
+	@Test(expected=InexistentEntityException.class)
 	public void testPackageExists() throws InexistentEntityException {
 	
 		PackageNode packageNode = dw.getPackage("org.designwizard.common");
-		assertEquals("org.designwizard.common",packageNode.getName());
+		Assert.assertEquals("org.designwizard.common",packageNode.getName());
 		
-		try {
-			packageNode = dw.getPackage("org.designwizard.comparator");
-			fail("This line cannot be processed");
-		} catch (InexistentEntityException e) {}
+		packageNode = dw.getPackage("org.designwizard.comparator");
 		
 		packageNode = dw.getPackage("org.designwizard.design");
-		assertEquals("org.designwizard.design",packageNode.getName());
+		Assert.assertEquals("org.designwizard.design",packageNode.getName());
 		
 		packageNode = dw.getPackage("org.designwizard.design.factory");
-		assertEquals("org.designwizard.design.factory",packageNode.getName());
+		Assert.assertEquals("org.designwizard.design.factory",packageNode.getName());
 		
 		packageNode = dw.getPackage("org.designwizard.design.manager");
-		assertEquals("org.designwizard.design.manager",packageNode.getName());
+		Assert.assertEquals("org.designwizard.design.manager",packageNode.getName());
 		
 		packageNode = dw.getPackage("org.designwizard.design.manager.util");
-		assertEquals("org.designwizard.design.manager.util",packageNode.getName());
+		Assert.assertEquals("org.designwizard.design.manager.util",packageNode.getName());
 		
 		packageNode = dw.getPackage("org.designwizard.design.factory");
-		assertEquals("org.designwizard.design.factory",packageNode.getName());
-	
+		Assert.assertEquals("org.designwizard.design.factory",packageNode.getName());
 	}
-	
+
+	@Test
 	public void testPackagesWithRegularExpressions() throws InexistentEntityException {
-		
 		// Testa o retorno dos pacotes que contém a string "api"
 		Set<PackageNode> packagesThatContainsApi = dw.getPackages(".*api.*");
-		assertFalse(packagesThatContainsApi.isEmpty());
-		assertTrue(packagesThatContainsApi.contains(dw.getPackage("org.designwizard.api")));
-		assertTrue(packagesThatContainsApi.contains(dw.getPackage("org.designwizard.api.util")));
-		assertTrue(packagesThatContainsApi.size() == 2);
+		Assert.assertFalse(packagesThatContainsApi.isEmpty());
+		Assert.assertTrue(packagesThatContainsApi.contains(dw.getPackage("org.designwizard.api")));
+		Assert.assertTrue(packagesThatContainsApi.contains(dw.getPackage("org.designwizard.api.util")));
+		Assert.assertTrue(packagesThatContainsApi.size() == 2);
 		
 		// Testa o retorno dos pacotes que terminam com a string "api"
 		Set<PackageNode> packagesFinishWithApi = dw.getPackages(".*api$");
-		assertFalse(packagesFinishWithApi.isEmpty());
-		assertTrue(packagesFinishWithApi.contains(dw.getPackage("org.designwizard.api")));
-		assertTrue(packagesFinishWithApi.size() == 1);
+		Assert.assertFalse(packagesFinishWithApi.isEmpty());
+		Assert.assertTrue(packagesFinishWithApi.contains(dw.getPackage("org.designwizard.api")));
+		Assert.assertTrue(packagesFinishWithApi.size() == 1);
 		
 		// Testa o retorno dos pacotes que iniciam com a string "api"
 		Set<PackageNode> packagesStartingWithApi = dw.getPackages("^api.*");
-		assertTrue(packagesStartingWithApi.isEmpty());
+		Assert.assertTrue(packagesStartingWithApi.isEmpty());
 		
 		// Testa o retorno dos pacotes que contém a string "api" ou "util"
 		Set<PackageNode> packagesThatContainsApiOrUtil = dw.getPackages(".*api.*|.*util.*");
-		assertFalse(packagesThatContainsApiOrUtil.isEmpty());
-		assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.api")));
-		assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.api.util")));
-		assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.extractor.asm.util")));
-		assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("tests.org.designwizard.design.manager.util")));
-		assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.design.manager.util")));
-		assertTrue(packagesThatContainsApiOrUtil.size() == 5);
+		Assert.assertFalse(packagesThatContainsApiOrUtil.isEmpty());
+		Assert.assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.api")));
+		Assert.assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.api.util")));
+		Assert.assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.extractor.asm.util")));
+		Assert.assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("tests.org.designwizard.design.manager.util")));
+		Assert.assertTrue(packagesThatContainsApiOrUtil.contains(dw.getPackage("org.designwizard.design.manager.util")));
+		Assert.assertTrue(packagesThatContainsApiOrUtil.size() == 5);
 	}
 	
+	@Test
 	public void testCallingMethods() throws InexistentEntityException {
-	
 		PackageNode packageNode = dw.getPackage("tests.org.designwizard.design");
-		assertEquals("tests.org.designwizard.design",packageNode.getName());
+		Assert.assertEquals("tests.org.designwizard.design",packageNode.getName());
 		
 		Set<MethodNode> callingMethods = packageNode.getCallerMethods();
-		assertFalse(callingMethods.isEmpty());
-		assertTrue(callingMethods.contains(dw.getMethod("tests.suites.AllTests.suite()")));
+		Assert.assertFalse(callingMethods.isEmpty());
+		Assert.assertTrue(callingMethods.contains(dw.getMethod("tests.suites.AllTests.suite()")));
 		
 		packageNode = dw.getPackage("org.designwizard.api.util");
 		callingMethods = packageNode.getCallerMethods();
-		assertFalse(callingMethods.isEmpty());
-	
+		Assert.assertFalse(callingMethods.isEmpty());
 	}
 	
 	//FIXME pensar neste caso! eu sou contra a maneira como estão sendo interpretado os pacotes.
+	@Test(expected=InexistentEntityException.class)
 	public void testContainsClass() throws InexistentEntityException {
-		
 		// packages that do not contain classes are not extracted (eu não concordo com isso :) )
-		PackageNode packageNode = null;
-		try {
-			packageNode = dw.getPackage("org.designwizard");
-			fail("This line cannot be processed");
-		} catch (InexistentEntityException e) {
-		}
-		
+		PackageNode packageNode = dw.getPackage("org.designwizard");
 		
 		packageNode = dw.getPackage("tests.org.designwizard.design");
-		assertTrue(packageNode.getAllClasses().contains(this.dw.getClass(PackageExtractionTest.class)));
+		Assert.assertTrue(packageNode.getAllClasses().contains(this.dw.getClass(PackageExtractionTest.class)));
 		
 		packageNode = dw.getPackage("org.designwizard.design.relation");
-		assertFalse(packageNode.getAllClasses().contains(this.dw.getClass(PackageExtractionTest.class)));
+		Assert.assertFalse(packageNode.getAllClasses().contains(this.dw.getClass(PackageExtractionTest.class)));
 		
-		try {
-			packageNode = dw.getPackage("default");
-			fail("This line cannot be processed");
-		} catch (InexistentEntityException e) {}
-	
+		packageNode = dw.getPackage("default");
 	}
 }

--- a/src_tests/tests/org/designwizard/design/RedBarTest.java
+++ b/src_tests/tests/org/designwizard/design/RedBarTest.java
@@ -5,19 +5,20 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.FieldNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * This class is a test composition class. I made some tests that must be executed to show to programmers
  * that their source code have some undesirable feature in Design. 
  * @author Jo�o Arthur Brunet Monteiro - joaoarthur@gmail.com - Grupo de M�todos Formais (GMF)
  */
-public class RedBarTest extends TestCase{
+public class RedBarTest  {
 	
 	/**
 	 * Attribute
@@ -28,8 +29,8 @@ public class RedBarTest extends TestCase{
 	 * Creates a new DesignWizard.
 	 * @throws IOException
 	 */
-	@Override
-	protected void setUp() throws IOException {
+	@Before
+	public void setUp() throws IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"edados1.jar");
 	}
 	
@@ -37,8 +38,8 @@ public class RedBarTest extends TestCase{
 	 * Tests structural features from software source code.
 	 * @throws InexistentEntityException
 	 */
+	@Test
 	public void testDesign() throws InexistentEntityException {
-		
 		 
 		//all classes from code
 		Set<ClassNode> classes = dw.getAllClasses();
@@ -52,30 +53,28 @@ public class RedBarTest extends TestCase{
 		f = this.dw.getField("java.lang.System.out");
 		uis.addAll(f.getCallerClasses());
 		
-		assertEquals(1, uis.size());
+		Assert.assertEquals(1, uis.size());
 		ClassNode ui = new LinkedList<ClassNode>(uis).getFirst();
 		
         //source code is organized in UI + CONTROL + BUSINESS LOGIC
-		
 		
 		//identifying CONTROL
 		
 		Set<ClassNode> control = ui.getCalleeClasses();
 		control.remove(ui);
 		
-		
 		//identifying LOGIC
 		Set <ClassNode> logic = classes;
 		logic.removeAll(control);
 		logic.remove(ui);
 		
-		assertFalse(uis.isEmpty());
-		assertFalse(control.isEmpty());
-		assertFalse(logic.isEmpty());
+		Assert.assertFalse(uis.isEmpty());
+		Assert.assertFalse(control.isEmpty());
+		Assert.assertFalse(logic.isEmpty());
 		
 		// there is no entity that knows or use UI.
 		Set<ClassNode> useUI = ui.getCallerClasses();
 		useUI.remove(ui);
-		assertTrue(useUI.isEmpty());
+		Assert.assertTrue(useUI.isEmpty());
 	}
 }

--- a/src_tests/tests/org/designwizard/design/manager/util/TranslatorUtilTest.java
+++ b/src_tests/tests/org/designwizard/design/manager/util/TranslatorUtilTest.java
@@ -2,21 +2,21 @@ package tests.org.designwizard.design.manager.util;
 
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.MethodNode;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class TranslatorUtilTest extends TestCase {
-
+public class TranslatorUtilTest {
 	
+	@Test
 	public void testJustOneLetter() throws IOException, InexistentEntityException {
 		DesignWizard dw = new DesignWizard("resources/testFiles/justOneLetter.jar");
 		ClassNode clazz = dw.getClass("Z");
 		MethodNode method = clazz.getDeclaredMethod("start()");
 		ClassNode returnType = method.getReturnType();
-		assertEquals("void", returnType.getName());
+		Assert.assertEquals("void", returnType.getName());
 	}
 }

--- a/src_tests/tests/org/designwizard/design/relation/RelationTest.java
+++ b/src_tests/tests/org/designwizard/design/relation/RelationTest.java
@@ -1,26 +1,28 @@
 package tests.org.designwizard.design.relation;
 
-import junit.framework.TestCase;
-
 import org.designwizard.design.AbstractEntity;
 import org.designwizard.design.ClassNode;
 import org.designwizard.design.MethodNode;
 import org.designwizard.design.Modifier;
 import org.designwizard.design.relation.Relation;
 import org.designwizard.design.relation.Relation.TypesOfRelation;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author jarthur
  * This class tests all the classes that implements the Relation interface.
  */
-public class RelationTest extends TestCase {
+public class RelationTest {
 	
 	private Relation r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12;
 	private AbstractEntity c1,c2,c3,c4, m1,m2,m3,m4;
 	
 	
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 	
 		this.c1 = new ClassNode("ContainRelation");
 		c1.addModifier(Modifier.PUBLIC);
@@ -67,8 +69,8 @@ public class RelationTest extends TestCase {
 		r12 = new Relation(c1,m1,TypesOfRelation.CONTAINS);
 	}
 	
-	@Override
-	protected void tearDown() {
+	@After
+	public void tearDown() {
 		this.r1 = null;
 		this.r2 = null;
 		this.r3 = null;
@@ -86,12 +88,13 @@ public class RelationTest extends TestCase {
 		
 	}
 	
+	@Test
 	public void testEquals() {
-		assertFalse(r1.equals(r2));
-		assertFalse(r3.equals(r4));
-		assertFalse(r5.equals(r6));
-		assertTrue(r7.equals(r8));
-		assertTrue(r9.equals(r10));
-		assertTrue(r11.equals(r12));
+		Assert.assertFalse(r1.equals(r2));
+		Assert.assertFalse(r3.equals(r4));
+		Assert.assertFalse(r5.equals(r6));
+		Assert.assertTrue(r7.equals(r8));
+		Assert.assertTrue(r9.equals(r10));
+		Assert.assertTrue(r11.equals(r12));
 	}
 }

--- a/src_tests/tests/org/designwizard/extractor/ASMExtractorTest.java
+++ b/src_tests/tests/org/designwizard/extractor/ASMExtractorTest.java
@@ -3,13 +3,13 @@ package tests.org.designwizard.extractor;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.exception.InexistentEntityException;
+import org.junit.Assert;
+import org.junit.Test;
 
 
-public class ASMExtractorTest extends TestCase {
+public class ASMExtractorTest {
 	
 	private DesignWizard dw;
 	
@@ -24,131 +24,73 @@ public class ASMExtractorTest extends TestCase {
 	private static final String DIRECTORY_PATH = "resources" + fs + "test_aplications" + fs
 	+ "Ear" + fs + "classes";
 	
-
-
+	@Test(expected=Exception.class)
 	public void testEarExtractor() throws IOException, InexistentEntityException {
-		
 		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.war", "WEB-INF/lib/jetty.jar");
 		                           
-		assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
-		assertNotNull(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler"));
-		assertFalse(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler").getAllMethods().isEmpty());
+		Assert.assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
+		Assert.assertNotNull(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler"));
+		Assert.assertFalse(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler").getAllMethods().isEmpty());
 		
 		this.dw = new DesignWizard(EAR_PROJECT_PATH, "META-INF/classes/");
         
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
-		assertFalse(dw.getClass("com.kbtflawt.server.ejb.Publisher").getAllMethods().isEmpty());
-		
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
+		Assert.assertFalse(dw.getClass("com.kbtflawt.server.ejb.Publisher").getAllMethods().isEmpty());
 		
 		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample-support.jar");
 		
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
-		assertFalse (dw.getClass("org.mortbay.cometd.AbstractTransport").getAllMethods().isEmpty());
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
+		Assert.assertFalse (dw.getClass("org.mortbay.cometd.AbstractTransport").getAllMethods().isEmpty());
 		
-		try {
-			this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample-support.jar", "tEste");
-			fail();
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(EAR_PROJECT_PATH, "META-INF/classes/", "TEste");
-			fail();
-		}catch (Exception e) {	}
-		
-		
+		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample-support.jar", "tEste");
+		this.dw = new DesignWizard(EAR_PROJECT_PATH, "META-INF/classes/", "TEste");
 		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.war", "WEB-INF/classes/");
 		
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
-		assertFalse(dw.getClass("com.kbtflawt.server.ejb.Publisher").getAllMethods().isEmpty());
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
+		Assert.assertFalse(dw.getClass("com.kbtflawt.server.ejb.Publisher").getAllMethods().isEmpty());
 		
-		try {
-			this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.war", "WEB-INF/classes/com/kbtflawt/server/ejb/DirectoryPoller.java");
-			fail("Should had thrown Exception for unexisting path");
-		}catch (Exception e) {	}
-		
-		
-		try {
-			this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.java");
-			fail("Should had thrown Exception for unexisting path");
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(EAR_PROJECT_PATH);
-		}catch (Exception e) {
-			fail("Should NOT had thrown Exception for existing path");
-		}
-		
+		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.war", "WEB-INF/classes/com/kbtflawt/server/ejb/DirectoryPoller.java");
+		this.dw = new DesignWizard(EAR_PROJECT_PATH, "dashsample.java");
+		this.dw = new DesignWizard(EAR_PROJECT_PATH);
 	}
 	
+	@Test(expected=Exception.class)
 	public void testWarExtractor () throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard(WAR_PROJECT_PATH, "WEB-INF/classes/");
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
 		
 		this.dw = new DesignWizard(WAR_PROJECT_PATH, "");
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
-		assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
-		assertNotNull(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
+		Assert.assertNotNull(dw.getClass("org.mortbay.cometd.AbstractTransport"));
+		Assert.assertNotNull(dw.getClass("org.mortbay.cometd.Bayeux$HandshakeHandler"));
 		
-		try {
-			this.dw = new DesignWizard(WAR_PROJECT_PATH,  "WEB-INF/classes/", "teste");
-			fail("Should had thrown Exception for unexisting path");
-		}catch (Exception e) {	}
+		this.dw = new DesignWizard(WAR_PROJECT_PATH,  "WEB-INF/classes/", "teste");
 		
-		try {
-			this.dw = new DesignWizard(WAR_PROJECT_PATH,  "WEB-INF/lib/jetty-util-6.0.1.jar", "teste");
-			fail("Should had thrown Exception for unexisting path");
-		}catch (Exception e) {	}
+		this.dw = new DesignWizard(WAR_PROJECT_PATH,  "WEB-INF/lib/jetty-util-6.0.1.jar", "teste");
 		
-		try {
-			this.dw = new DesignWizard(WAR_PROJECT_PATH, "dashsample.java");
-			fail("Should had thrown Exception for unexisting path");
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(WAR_PROJECT_PATH);
-		}catch (Exception e) {
-			fail("Should not had thrown Exception for existing path");
-		}
-		
+		this.dw = new DesignWizard(WAR_PROJECT_PATH, "dashsample.java");
+		this.dw = new DesignWizard(WAR_PROJECT_PATH);		
 	}
 	
+	@Test(expected=Exception.class)
 	public void testDirectoryExtractor () throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard(DIRECTORY_PATH);
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
-		assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPoller"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.DirectoryPollerEJBLocalHome"));
+		Assert.assertNotNull(dw.getClass("com.kbtflawt.server.ejb.Publisher"));
 		
-		try {
-			this.dw = new DesignWizard(DIRECTORY_PATH,  "WEB-INF/classes/", "teste");
-			fail();
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(DIRECTORY_PATH,  "WEB-INF/lib/jetty-util-6.0.1.jar", "teste");
-			fail();
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(DIRECTORY_PATH, "dashsample.java");
-			fail();
-		}catch (Exception e) {	}
-		
-		try {
-			this.dw = new DesignWizard(DIRECTORY_PATH, "com");
-			fail();
-		}catch (Exception e) {	}
-		
-	}
-
-	
-	
+		this.dw = new DesignWizard(DIRECTORY_PATH,  "WEB-INF/classes/", "teste");
+		this.dw = new DesignWizard(DIRECTORY_PATH,  "WEB-INF/lib/jetty-util-6.0.1.jar", "teste");
+		this.dw = new DesignWizard(DIRECTORY_PATH, "dashsample.java");
+		this.dw = new DesignWizard(DIRECTORY_PATH, "com");
+	}	
 }

--- a/src_tests/tests/org/designwizard/patternchecker/SingletonPatternCheckerTest.java
+++ b/src_tests/tests/org/designwizard/patternchecker/SingletonPatternCheckerTest.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.designwizard.api.DesignWizard;
 import org.designwizard.design.ClassNode;
 import org.designwizard.exception.InexistentEntityException;
@@ -14,18 +12,21 @@ import org.designwizard.patternchecker.CheckWarning;
 import org.designwizard.patternchecker.CheckingResult;
 import org.designwizard.patternchecker.PatternChecker;
 import org.designwizard.patternchecker.SingletonPatternChecker;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class SingletonPatternCheckerTest extends TestCase {
+public class SingletonPatternCheckerTest {
 	
 	private DesignWizard dw;
 
+	@Test
 	public void testWhetherIsSingleton() throws InexistentEntityException, IOException {
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"singleton.jar");
 
 		ClassNode classEntity = this.dw.getClass("SingletonImplementation");
 		PatternChecker checker = new SingletonPatternChecker(classEntity);
 		checker.verify();
-		assertTrue(checker.getVeredict());
+		Assert.assertTrue(checker.getVeredict());
 
 		/* Test with a public constructor */
 		this.dw = new DesignWizard("resources"+File.separator+"testFiles"+File.separator+"singletonBadConstructor1.jar");
@@ -33,12 +34,12 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonBadConstructor");
 		checker = new SingletonPatternChecker(classEntity);
 		CheckingResult resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		Set<CheckError> errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		CheckError uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.PUBLIC_CONSTRUCTOR_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.PUBLIC_CONSTRUCTOR_ERROR, 
 				uniqueError.getErrorMessage());
 
 		/* Test with a public Singleton instance */
@@ -47,18 +48,18 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonPublicField");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
 				uniqueError.getErrorMessage());
 
 		Set<CheckWarning> warnings = resultOfCheck.getWarnings();
-		assertEquals(1, warnings.size());
+		Assert.assertEquals(1, warnings.size());
 		CheckWarning uniqueWarning = warnings.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
 				uniqueWarning.getMessage());
 		
 		/* Test without Singleton instance as field */
@@ -67,18 +68,18 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonWithoutField");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
 				uniqueError.getErrorMessage());
 
 		warnings = resultOfCheck.getWarnings();
-		assertEquals(1, warnings.size());
+		Assert.assertEquals(1, warnings.size());
 		uniqueWarning = warnings.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
 				uniqueWarning.getMessage());
 		
 		/* Test with non static Singleton instance as field */
@@ -87,18 +88,18 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonNonStaticField");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.NO_SINGLETON_FIELDS_ERROR, 
 				uniqueError.getErrorMessage());
 
 		warnings = resultOfCheck.getWarnings();
-		assertEquals(1, warnings.size());
+		Assert.assertEquals(1, warnings.size());
 		uniqueWarning = warnings.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_FIELD_MISS_WARN, 
 				uniqueWarning.getMessage());
 
 
@@ -111,12 +112,12 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonGetInstanceWithoutFieldAcess");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
 				uniqueError.getErrorMessage());
 
 		/* Test getInstance without static modifier */
@@ -124,12 +125,12 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonNonStaticGetInstance");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
 				uniqueError.getErrorMessage());
 
 		/* Test without getInstance */
@@ -137,12 +138,12 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonWithoutGetInstance");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
 				uniqueError.getErrorMessage());
 
 		/* Test getInstance with private modifier */
@@ -150,12 +151,12 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonWithPrivateGetInstance");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertFalse(checker.getVeredict());
+		Assert.assertFalse(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(1, errors.size());
+		Assert.assertEquals(1, errors.size());
 		uniqueError = errors.iterator().next();
-		assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
+		Assert.assertEquals(SingletonPatternChecker.GET_INSTANCE_NOT_FOUND_ERROR, 
 				uniqueError.getErrorMessage());
 
 		/* *********** TESTING CORRECT IMPLEMENTATIONS ************* */
@@ -165,19 +166,17 @@ public class SingletonPatternCheckerTest extends TestCase {
 		classEntity = this.dw.getClass("SingletonCorrect1");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertTrue(checker.getVeredict());
+		Assert.assertTrue(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(0, errors.size());
+		Assert.assertEquals(0, errors.size());
 
 		classEntity = this.dw.getClass("SingletonCorrect2");
 		checker = new SingletonPatternChecker(classEntity);
 		resultOfCheck = checker.verify();
-		assertTrue(checker.getVeredict());
+		Assert.assertTrue(checker.getVeredict());
 		
 		errors = resultOfCheck.getErrors();
-		assertEquals(0, errors.size());
-
-	
+		Assert.assertEquals(0, errors.size());
 	}
 }

--- a/src_tests/tests/suites/AllTests.java
+++ b/src_tests/tests/suites/AllTests.java
@@ -1,13 +1,15 @@
 package tests.suites;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
 import junit.framework.TestSuite;
 import tests.org.designwizard.design.AbstractEntityTest;
 import tests.org.designwizard.design.AllClassesInSuiteTest;
 import tests.org.designwizard.design.AnnotationsExtractTest;
 import tests.org.designwizard.design.AnnotationsOfClassTest;
 import tests.org.designwizard.design.AnnotationsOfFieldTest;
+import tests.org.designwizard.design.AnnotationsOfMethodTest;
 import tests.org.designwizard.design.CatchBlockTest;
 import tests.org.designwizard.design.CatchedExceptionsTest;
 import tests.org.designwizard.design.ClassNodeTest;
@@ -23,34 +25,55 @@ import tests.org.designwizard.design.relation.RelationTest;
 import tests.org.designwizard.extractor.ASMExtractorTest;
 import tests.org.designwizard.patternchecker.SingletonPatternCheckerTest;
 
-public class AllTests extends TestCase {
-	
-	public static Test suite() {
+@RunWith(Suite.class)
+@Suite.SuiteClasses({ 
+		AbstractEntityTest.class, 
+		AllClassesInSuiteTest.class, 
+		AnnotationsExtractTest.class,
+		AnnotationsOfClassTest.class,
+        AnnotationsOfFieldTest.class, 
+        AnnotationsOfMethodTest.class, 
+        CatchBlockTest.class,
+		CatchedExceptionsTest.class, 
+		ClassNodeTest.class, 
+		EntityTest.class, 
+		FieldNodeTest.class, 
+		InheritanceTest.class,
+		InternalClassExtractionTest.class, 
+		MethodNodeTest.class, 
+		PackageExtractionTest.class, 
+		RedBarTest.class,
+
+		TranslatorUtilTest.class,
+
+		ASMExtractorTest.class,
+
+		RelationTest.class, SingletonPatternCheckerTest.class })
+
+public final class AllTests {
+	//FIXME Esse método não deveria existir.
+	// Tá aqui apenas para o test ClassNodeTest.getLoadClass() 
+	public void suite() {
 		TestSuite suite = new TestSuite("Test for DesignWizard");
-		
-		//$JUnit-BEGIN$
-		suite.addTest(new TestSuite(RelationTest.class));
-		suite.addTest(new TestSuite(CatchBlockTest.class));
-		suite.addTest(new TestSuite(CatchedExceptionsTest.class));
-		suite.addTest(new TestSuite(FieldNodeTest.class));
-		suite.addTest(new TestSuite(ClassNodeTest.class));
-		suite.addTest(new TestSuite(AllClassesInSuiteTest.class));
-		suite.addTest(new TestSuite(SingletonPatternCheckerTest.class));
-		suite.addTest(new TestSuite(MethodNodeTest.class));
 		suite.addTest(new TestSuite(AbstractEntityTest.class));
-		suite.addTest(new TestSuite(InheritanceTest.class));
-		suite.addTest(new TestSuite(RedBarTest.class));
-		suite.addTest(new TestSuite(EntityTest.class));
-		suite.addTest(new TestSuite(TranslatorUtilTest.class));
-		suite.addTest(new TestSuite(PackageExtractionTest.class));
-		suite.addTest(new TestSuite(InternalClassExtractionTest.class));
-		suite.addTest(new TestSuite(ASMExtractorTest.class));
+		suite.addTest(new TestSuite(AllClassesInSuiteTest.class));
 		suite.addTest(new TestSuite(AnnotationsOfClassTest.class));
 		suite.addTest(new TestSuite(AnnotationsOfFieldTest.class));
 		suite.addTest(new TestSuite(AnnotationsExtractTest.class));
-		
-		//$JUnit-END$
-		return suite;
-	
+		suite.addTest(new TestSuite(AnnotationsOfMethodTest.class));
+		suite.addTest(new TestSuite(ASMExtractorTest.class));
+		suite.addTest(new TestSuite(CatchBlockTest.class));
+		suite.addTest(new TestSuite(CatchedExceptionsTest.class));
+		suite.addTest(new TestSuite(ClassNodeTest.class));
+		suite.addTest(new TestSuite(EntityTest.class));
+		suite.addTest(new TestSuite(FieldNodeTest.class));
+		suite.addTest(new TestSuite(InheritanceTest.class));
+		suite.addTest(new TestSuite(InternalClassExtractionTest.class));
+		suite.addTest(new TestSuite(MethodNodeTest.class));
+		suite.addTest(new TestSuite(PackageExtractionTest.class));
+		suite.addTest(new TestSuite(RedBarTest.class));
+		suite.addTest(new TestSuite(TranslatorUtilTest.class));
+		suite.addTest(new TestSuite(SingletonPatternCheckerTest.class));
+		suite.addTest(new TestSuite(RelationTest.class));
 	}
 }


### PR DESCRIPTION
Fixed the following warnings:

- The method toURL() is deprecated.
- Class is raw type. Class is a raw type. References to generic type Class<T> should be parameterized.
- The serializable class does not declare a static final serialVersionUID field of type long.
- Open files are now closed.